### PR TITLE
feat(rust): add envconfig crate for configuration parsing

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+envconfig = { path = "envconfig" }
 
 [build-dependencies]
 cc = "1.0"

--- a/rust/cli/Cargo.lock
+++ b/rust/cli/Cargo.lock
@@ -159,6 +159,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
+ "envconfig",
  "predicates",
  "tempfile",
 ]
@@ -176,10 +177,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6184e33543162437515c2e2b48714794e37845ec9851711914eec9d308f6ebe8"
 
 [[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "doc-comment"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fea41bba32d969b513997752735605054bc0dfa92b4c56bf1189f2e174be7a10"
+
+[[package]]
+name = "envconfig"
+version = "0.1.0"
+dependencies = [
+ "dirs",
+ "humantime",
+ "log",
+]
 
 [[package]]
 name = "errno"
@@ -208,6 +239,17 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -215,7 +257,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
- "wasi",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -223,6 +265,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "humantime"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -237,10 +285,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "log"
+version = "0.4.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "memchr"
@@ -274,6 +338,12 @@ name = "once_cell_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "predicates"
@@ -328,6 +398,17 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "redox_users"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror",
+]
 
 [[package]]
 name = "regex"
@@ -415,7 +496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.61.0",
@@ -426,6 +507,26 @@ name = "termtree"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -447,6 +548,12 @@ checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
@@ -480,11 +587,20 @@ checksum = "45e46c0661abb7180e7b9c281db115305d49ca1709ab8242adf09666d2173c65"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -498,20 +614,41 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
 dependencies = [
  "windows-link 0.1.3",
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -521,9 +658,21 @@ checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -539,9 +688,21 @@ checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -551,9 +712,21 @@ checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/rust/cli/Cargo.toml
+++ b/rust/cli/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
+envconfig = { path = "../envconfig" }
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/rust/cli/src/lib.rs
+++ b/rust/cli/src/lib.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 use anyhow::{Result, bail};
 use clap::{Parser, Subcommand};
 
+pub use envconfig;
+
 #[derive(Parser)]
 #[command(name = "ollama", about = "Rust reimplementation of the Ollama CLI")]
 pub struct Cli {

--- a/rust/envconfig/Cargo.lock
+++ b/rust/envconfig/Cargo.lock
@@ -9,16 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
-name = "cc"
-version = "1.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65193589c6404eb80b450d618eaf9a2cafaaafd57ecce47370519ef674a7bd44"
-dependencies = [
- "find-msvc-tools",
- "shlex",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,12 +43,6 @@ dependencies = [
  "humantime",
  "log",
 ]
-
-[[package]]
-name = "find-msvc-tools"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
 
 [[package]]
 name = "getrandom"
@@ -106,14 +90,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "oxi_rust"
-version = "0.1.0"
-dependencies = [
- "cc",
- "envconfig",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,12 +117,6 @@ dependencies = [
  "libredox",
  "thiserror",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "syn"

--- a/rust/envconfig/Cargo.toml
+++ b/rust/envconfig/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "envconfig"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+dirs = "5"
+humantime = "2"
+log = "0.4"

--- a/rust/envconfig/src/lib.rs
+++ b/rust/envconfig/src/lib.rs
@@ -1,0 +1,182 @@
+use std::env;
+use std::net::IpAddr;
+use std::path::PathBuf;
+use std::time::Duration;
+use log::warn;
+
+/// Returns the scheme and host. Host can be configured via the OLLAMA_HOST environment variable.
+/// Default is scheme "http" and host "127.0.0.1:11434".
+pub fn host() -> String {
+    let mut default_port = "11434".to_string();
+
+    let s = var("OLLAMA_HOST").trim().to_string();
+    let (scheme, rest) = match s.split_once("://") {
+        Some((sch, hp)) => {
+            if sch == "http" { default_port = "80".into(); }
+            else if sch == "https" { default_port = "443".into(); }
+            (sch.to_string(), hp.to_string())
+        }
+        None => ("http".into(), s),
+    };
+
+    let (hostport, path) = match rest.split_once('/') {
+        Some((hp, p)) => (hp.to_string(), p.to_string()),
+        None => (rest, String::new()),
+    };
+
+    let mut host = "127.0.0.1".to_string();
+    let mut port = default_port.clone();
+
+    if let Some((h, p)) = split_host_port(&hostport) {
+        host = h;
+        port = p;
+    } else {
+        let trimmed = hostport.trim_matches(['[', ']']);
+        if let Ok(ip) = trimmed.parse::<IpAddr>() {
+            host = ip.to_string();
+        } else if !hostport.is_empty() {
+            host = hostport;
+        }
+    }
+
+    if let Ok(n) = port.parse::<i64>() {
+        if n < 0 || n > 65535 {
+            warn!("invalid port, using default {}", default_port);
+            port = default_port.clone();
+        }
+    } else {
+        warn!("invalid port, using default {}", default_port);
+        port = default_port.clone();
+    }
+
+    let hostport = join_host_port(&host, &port);
+    let mut url_str = format!("{}://{}", scheme, hostport);
+    if !path.is_empty() {
+        url_str.push('/');
+        url_str.push_str(&path);
+    }
+    url_str
+}
+
+/// AllowedOrigins returns a list of allowed origins. AllowedOrigins can be configured via the OLLAMA_ORIGINS environment variable.
+pub fn allowed_origins() -> Vec<String> {
+    let mut origins: Vec<String> = Vec::new();
+    let s = var("OLLAMA_ORIGINS");
+    if !s.is_empty() {
+        origins.extend(s.split(',').map(|s| s.to_string()));
+    }
+
+    for origin in ["localhost", "127.0.0.1", "0.0.0.0"].iter() {
+        origins.push(format!("http://{}", origin));
+        origins.push(format!("https://{}", origin));
+        origins.push(format!("http://{}:*", origin));
+        origins.push(format!("https://{}:*", origin));
+    }
+
+    origins.extend([
+        "app://*".to_string(),
+        "file://*".to_string(),
+        "tauri://*".to_string(),
+        "vscode-webview://*".to_string(),
+        "vscode-file://*".to_string(),
+    ]);
+
+    origins
+}
+
+/// Models returns the path to the models directory. Models directory can be configured via the OLLAMA_MODELS environment variable.
+/// Default is $HOME/.ollama/models
+pub fn models() -> PathBuf {
+    if let Ok(s) = env::var("OLLAMA_MODELS") {
+        if !s.is_empty() {
+            return PathBuf::from(s);
+        }
+    }
+    let home = dirs::home_dir().expect("home directory not found");
+    home.join(".ollama").join("models")
+}
+
+/// KeepAlive returns the duration that models stay loaded in memory. KeepAlive can be configured via the OLLAMA_KEEP_ALIVE environment variable.
+/// Negative values are treated as infinite. Zero is treated as no keep alive.
+/// Default is 5 minutes.
+pub fn keep_alive() -> Duration {
+    let secs = parse_duration_env("OLLAMA_KEEP_ALIVE").unwrap_or(300);
+    if secs < 0 {
+        Duration::MAX
+    } else {
+        Duration::from_secs(secs as u64)
+    }
+}
+
+/// LoadTimeout returns the duration for stall detection during model loads. LoadTimeout can be configured via the OLLAMA_LOAD_TIMEOUT environment variable.
+/// Zero or Negative values are treated as infinite.
+/// Default is 5 minutes.
+pub fn load_timeout() -> Duration {
+    let secs = parse_duration_env("OLLAMA_LOAD_TIMEOUT").unwrap_or(300);
+    if secs <= 0 {
+        Duration::MAX
+    } else {
+        Duration::from_secs(secs as u64)
+    }
+}
+
+/// Var returns an environment variable stripped of leading and trailing quotes or spaces
+pub fn var(key: &str) -> String {
+    env::var(key)
+        .unwrap_or_default()
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}
+
+fn split_host_port(s: &str) -> Option<(String, String)> {
+    if s.starts_with('[') {
+        if let Some(end) = s.find(']') {
+            let host = &s[1..end];
+            let rest = &s[end + 1..];
+            if rest.starts_with(':') {
+                return Some((host.to_string(), rest[1..].to_string()));
+            }
+            return None;
+        }
+        return None;
+    }
+    if let Some(idx) = s.rfind(':') {
+        if s[..idx].contains(':') {
+            return None;
+        }
+        let host = &s[..idx];
+        let port = &s[idx + 1..];
+        return Some((host.to_string(), port.to_string()));
+    }
+    None
+}
+
+fn join_host_port(host: &str, port: &str) -> String {
+    if host.contains(':') && !(host.starts_with('[') && host.ends_with(']')) {
+        format!("[{}]:{}", host, port)
+    } else {
+        format!("{}:{}", host, port)
+    }
+}
+
+fn parse_duration_env(key: &str) -> Option<i64> {
+    let s = var(key);
+    if s.is_empty() {
+        return None;
+    }
+    let negative = s.trim_start().starts_with('-');
+    let s_trim = s.trim_start_matches('-');
+    if s_trim.contains('d') || s_trim.contains('w') || s_trim.contains('y') {
+        return None;
+    }
+    if let Ok(d) = humantime::parse_duration(s_trim) {
+        let secs = d.as_secs() as i64;
+        return Some(if negative { -secs } else { secs });
+    }
+    if let Ok(n) = s_trim.parse::<i64>() {
+        return Some(if negative { -n } else { n });
+    }
+    None
+}

--- a/rust/envconfig/tests/config.rs
+++ b/rust/envconfig/tests/config.rs
@@ -1,0 +1,227 @@
+use std::time::Duration;
+
+use envconfig::{allowed_origins, host, keep_alive, load_timeout, var};
+
+fn setenv(key: &str, val: &str) {
+    unsafe { std::env::set_var(key, val) }
+}
+fn unset(key: &str) {
+    unsafe { std::env::remove_var(key) }
+}
+
+#[test]
+fn test_host() {
+    let cases = [
+        ("", "http://127.0.0.1:11434"),
+        ("1.2.3.4", "http://1.2.3.4:11434"),
+        (":1234", "http://:1234"),
+        ("1.2.3.4:1234", "http://1.2.3.4:1234"),
+        ("example.com", "http://example.com:11434"),
+        ("example.com:1234", "http://example.com:1234"),
+        (":0", "http://:0"),
+        (":66000", "http://:11434"),
+        (":-1", "http://:11434"),
+        ("[::1]", "http://[::1]:11434"),
+        ("[::]", "http://[::]:11434"),
+        ("::1", "http://[::1]:11434"),
+        ("[::1]:1337", "http://[::1]:1337"),
+        (" 1.2.3.4 ", "http://1.2.3.4:11434"),
+        ("\"1.2.3.4\"", "http://1.2.3.4:11434"),
+        (" \" 1.2.3.4 \" ", "http://1.2.3.4:11434"),
+        ("'1.2.3.4'", "http://1.2.3.4:11434"),
+        ("http://1.2.3.4", "http://1.2.3.4:80"),
+        ("http://1.2.3.4:4321", "http://1.2.3.4:4321"),
+        ("https://1.2.3.4", "https://1.2.3.4:443"),
+        ("https://1.2.3.4:4321", "https://1.2.3.4:4321"),
+        ("https://example.com/ollama", "https://example.com:443/ollama"),
+    ];
+
+    for (value, expect) in cases {
+        setenv("OLLAMA_HOST", value);
+        let actual = host();
+        let actual = actual.trim_end_matches('/').to_string();
+        assert_eq!(actual, expect, "case {value:?}");
+    }
+    unset("OLLAMA_HOST");
+}
+
+#[test]
+fn test_origins() {
+    let cases = [
+        (
+            "",
+            vec![
+                "http://localhost",
+                "https://localhost",
+                "http://localhost:*",
+                "https://localhost:*",
+                "http://127.0.0.1",
+                "https://127.0.0.1",
+                "http://127.0.0.1:*",
+                "https://127.0.0.1:*",
+                "http://0.0.0.0",
+                "https://0.0.0.0",
+                "http://0.0.0.0:*",
+                "https://0.0.0.0:*",
+                "app://*",
+                "file://*",
+                "tauri://*",
+                "vscode-webview://*",
+                "vscode-file://*",
+            ],
+        ),
+        (
+            "http://10.0.0.1",
+            vec![
+                "http://10.0.0.1",
+                "http://localhost",
+                "https://localhost",
+                "http://localhost:*",
+                "https://localhost:*",
+                "http://127.0.0.1",
+                "https://127.0.0.1",
+                "http://127.0.0.1:*",
+                "https://127.0.0.1:*",
+                "http://0.0.0.0",
+                "https://0.0.0.0",
+                "http://0.0.0.0:*",
+                "https://0.0.0.0:*",
+                "app://*",
+                "file://*",
+                "tauri://*",
+                "vscode-webview://*",
+                "vscode-file://*",
+            ],
+        ),
+        (
+            "http://172.16.0.1,https://192.168.0.1",
+            vec![
+                "http://172.16.0.1",
+                "https://192.168.0.1",
+                "http://localhost",
+                "https://localhost",
+                "http://localhost:*",
+                "https://localhost:*",
+                "http://127.0.0.1",
+                "https://127.0.0.1",
+                "http://127.0.0.1:*",
+                "https://127.0.0.1:*",
+                "http://0.0.0.0",
+                "https://0.0.0.0",
+                "http://0.0.0.0:*",
+                "https://0.0.0.0:*",
+                "app://*",
+                "file://*",
+                "tauri://*",
+                "vscode-webview://*",
+                "vscode-file://*",
+            ],
+        ),
+        (
+            "http://totally.safe,http://definitely.legit",
+            vec![
+                "http://totally.safe",
+                "http://definitely.legit",
+                "http://localhost",
+                "https://localhost",
+                "http://localhost:*",
+                "https://localhost:*",
+                "http://127.0.0.1",
+                "https://127.0.0.1",
+                "http://127.0.0.1:*",
+                "https://127.0.0.1:*",
+                "http://0.0.0.0",
+                "https://0.0.0.0",
+                "http://0.0.0.0:*",
+                "https://0.0.0.0:*",
+                "app://*",
+                "file://*",
+                "tauri://*",
+                "vscode-webview://*",
+                "vscode-file://*",
+            ],
+        ),
+    ];
+
+    for (value, expect) in cases {
+        setenv("OLLAMA_ORIGINS", value);
+        assert_eq!(allowed_origins(), expect, "case {value}");
+    }
+    unset("OLLAMA_ORIGINS");
+}
+
+#[test]
+fn test_keep_alive() {
+    let cases = [
+        ("", Duration::from_secs(5 * 60)),
+        ("1s", Duration::from_secs(1)),
+        ("1m", Duration::from_secs(60)),
+        ("1h", Duration::from_secs(60 * 60)),
+        ("5m0s", Duration::from_secs(5 * 60)),
+        ("1h2m3s", Duration::from_secs(3723)),
+        ("0", Duration::from_secs(0)),
+        ("60", Duration::from_secs(60)),
+        ("120", Duration::from_secs(120)),
+        ("3600", Duration::from_secs(3600)),
+        ("-0", Duration::from_secs(0)),
+        ("-1", Duration::MAX),
+        ("-1m", Duration::MAX),
+        (" ", Duration::from_secs(5 * 60)),
+        ("???", Duration::from_secs(5 * 60)),
+        ("1d", Duration::from_secs(5 * 60)),
+        ("1y", Duration::from_secs(5 * 60)),
+        ("1w", Duration::from_secs(5 * 60)),
+    ];
+    for (value, expect) in cases {
+        setenv("OLLAMA_KEEP_ALIVE", value);
+        assert_eq!(keep_alive(), expect, "case {value}");
+    }
+    unset("OLLAMA_KEEP_ALIVE");
+}
+
+#[test]
+fn test_load_timeout() {
+    let default_timeout = Duration::from_secs(5 * 60);
+    let cases = [
+        ("", default_timeout),
+        ("1s", Duration::from_secs(1)),
+        ("1m", Duration::from_secs(60)),
+        ("1h", Duration::from_secs(60 * 60)),
+        ("5m0s", default_timeout),
+        ("1h2m3s", Duration::from_secs(3723)),
+        ("0", Duration::MAX),
+        ("60", Duration::from_secs(60)),
+        ("120", Duration::from_secs(120)),
+        ("3600", Duration::from_secs(3600)),
+        ("-0", Duration::MAX),
+        ("-1", Duration::MAX),
+        ("-1m", Duration::MAX),
+        (" ", default_timeout),
+        ("???", default_timeout),
+        ("1d", default_timeout),
+        ("1y", default_timeout),
+        ("1w", default_timeout),
+    ];
+    for (value, expect) in cases {
+        setenv("OLLAMA_LOAD_TIMEOUT", value);
+        assert_eq!(load_timeout(), expect, "case {value}");
+    }
+    unset("OLLAMA_LOAD_TIMEOUT");
+}
+
+#[test]
+fn test_var() {
+    let cases = [
+        ("value", "value"),
+        (" value ", "value"),
+        (" 'value' ", "value"),
+        (" \"value\" ", "value"),
+        (" ' value ' ", " value "),
+        (" \" value \" ", " value "),
+    ];
+    for (input, expect) in cases {
+        setenv("OLLAMA_VAR", input);
+        assert_eq!(var("OLLAMA_VAR"), expect, "case {input}");
+    }
+    unset("OLLAMA_VAR");
+}

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,3 +1,5 @@
+pub use envconfig;
+
 extern "C" {
     fn hello_from_c() -> i32;
 }


### PR DESCRIPTION
## Summary
- introduce `envconfig` crate for host, origin, models, keep-alive and load-timeout settings
- re-export envconfig for CLI and server crates
- add comprehensive unit tests mirroring Go config tests

## Testing
- `cargo test` (envconfig)
- `cargo test` (cli)
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c54db947a0832f8232975c01bec266