### PR TITLE
Auto distribute model layers across all GPUs

### DIFF
--- a/llama/llama.go
+++ b/llama/llama.go
@@ -17,6 +17,7 @@ package llama
 #include "mtmd.h"
 #include "mtmd-helper.h"
 #include "gguf.h"
+#include "ggml-backend.h"
 
 #include "sampling_ext.h"
 
@@ -60,6 +61,73 @@ func llamaLog(level C.int, text *C.char, _ unsafe.Pointer) {
 func BackendInit() {
 	ggml.OnceLoad()
 	C.llama_backend_init()
+}
+
+type DeviceInfo struct {
+	ID          string
+	Name        string
+	Description string
+	TotalMemory uint64
+	FreeMemory  uint64
+}
+
+// GPUDevices returns information about all detected GPU devices.
+// The function queries the ggml backend for device properties so that
+// scheduling decisions can take device capabilities and memory into account.
+func GPUDevices() []DeviceInfo {
+	var devices []DeviceInfo
+
+	for i := range C.ggml_backend_dev_count() {
+		dev := C.ggml_backend_dev_get(i)
+		if C.ggml_backend_dev_type(dev) != C.GGML_BACKEND_DEVICE_TYPE_GPU {
+			continue
+		}
+
+		var props C.struct_ggml_backend_dev_props
+		C.ggml_backend_dev_get_props(dev, &props)
+		devices = append(devices, DeviceInfo{
+			ID:          C.GoString(props.id),
+			Name:        C.GoString(props.name),
+			Description: C.GoString(props.description),
+			TotalMemory: uint64(props.memory_total),
+			FreeMemory:  uint64(props.memory_free),
+		})
+	}
+
+	return devices
+}
+
+// DefaultTensorSplit returns a tensor split based on the free memory of all
+// detected GPUs. The split is expressed as fractions that sum to 1.0 and can be
+// passed directly to the llama backend. The index of the GPU with the most
+// available memory is also returned to be used as the main GPU.
+func DefaultTensorSplit() ([]float32, int) {
+	devices := GPUDevices()
+	if len(devices) == 0 {
+		return nil, 0
+	}
+
+	split := make([]float32, len(devices))
+	var total uint64
+	best := 0
+	for i, d := range devices {
+		total += d.FreeMemory
+		if d.FreeMemory > devices[best].FreeMemory {
+			best = i
+		}
+	}
+
+	if total == 0 {
+		for i := range split {
+			split[i] = 1.0 / float32(len(split))
+		}
+	} else {
+		for i, d := range devices {
+			split[i] = float32(d.FreeMemory) / float32(total)
+		}
+	}
+
+	return split, best
 }
 
 func EnumerateGPUs() []string {

--- a/runner/llamarunner/runner.go
+++ b/runner/llamarunner/runner.go
@@ -810,11 +810,26 @@ func (s *Server) load(w http.ResponseWriter, r *http.Request) {
 		gpuIDs := llama.EnumerateGPUs()
 		tensorSplit := make([]float32, len(gpuIDs))
 		numGPU := 0
-		for i := range gpuIDs {
-			for _, layers := range req.GPULayers {
-				if gpuIDs[i] == layers.ID {
-					tensorSplit[i] = float32(len(layers.Layers))
-					numGPU += len(layers.Layers)
+
+		if len(req.GPULayers) == 0 {
+			// No explicit GPU layout provided - use all detected GPUs and
+			// split layers proportionally to available memory.
+			if split, main := llama.DefaultTensorSplit(); len(split) > 0 {
+				copy(tensorSplit, split)
+				if req.MainGPU == 0 && main < len(gpuIDs) {
+					req.MainGPU = main
+				}
+				// Offload as many layers as possible. The llama backend
+				// will clamp this to the model's layer count.
+				numGPU = 999
+			}
+		} else {
+			for i := range gpuIDs {
+				for _, layers := range req.GPULayers {
+					if gpuIDs[i] == layers.ID {
+						tensorSplit[i] = float32(len(layers.Layers))
+						numGPU += len(layers.Layers)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary
- detect and expose GPU device details, including free memory
- compute a default tensor split to evenly use all GPUs
- fall back to automatic GPU usage in runner when no explicit layout is provided

## Testing
- `go test ./llama ./runner/llamarunner` *(failed: build exceeded time limits)*

------
https://chatgpt.com/codex/tasks/task_b_68c558ce922c832fb88c6267fa91b362