### PR TITLE
feat: add progress crate with bar and spinner

### DIFF
--- a/rust/progress/Cargo.toml
+++ b/rust/progress/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "progress"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+console = "0.15"

--- a/rust/progress/src/bar.rs
+++ b/rust/progress/src/bar.rs
@@ -1,0 +1,203 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use console::Term;
+use crate::progress::State;
+
+pub struct Bar {
+    inner: Mutex<BarInner>,
+}
+
+struct BarInner {
+    message: String,
+    message_width: isize,
+    max_value: i64,
+    initial_value: i64,
+    current_value: i64,
+    started: Instant,
+    stopped: Option<Instant>,
+    buckets: Vec<Bucket>,
+    max_buckets: usize,
+}
+
+struct Bucket {
+    updated: Instant,
+    value: i64,
+}
+
+impl Bar {
+    pub fn new(message: impl Into<String>, max_value: i64, initial_value: i64) -> Self {
+        let inner = BarInner {
+            message: message.into(),
+            message_width: -1,
+            max_value,
+            initial_value,
+            current_value: initial_value,
+            started: Instant::now(),
+            stopped: if initial_value >= max_value { Some(Instant::now()) } else { None },
+            buckets: Vec::new(),
+            max_buckets: 10,
+        };
+        Bar { inner: Mutex::new(inner) }
+    }
+
+    pub fn set(&self, value: i64) {
+        let mut inner = self.inner.lock().unwrap();
+        let value = value.min(inner.max_value);
+        inner.current_value = value;
+        if inner.current_value >= inner.max_value {
+            if inner.stopped.is_none() {
+                inner.stopped = Some(Instant::now());
+            }
+        }
+        if inner.buckets.is_empty() || inner.buckets.last().unwrap().updated.elapsed() > Duration::from_secs(1) {
+            inner.buckets.push(Bucket { updated: Instant::now(), value });
+            if inner.buckets.len() > inner.max_buckets {
+                inner.buckets.remove(0);
+            }
+        }
+    }
+
+    fn percent(inner: &BarInner) -> f64 {
+        if inner.max_value > 0 {
+            inner.current_value as f64 / inner.max_value as f64 * 100.0
+        } else {
+            0.0
+        }
+    }
+
+    fn rate(inner: &BarInner) -> f64 {
+        let mut numerator = 0.0;
+        let mut denominator = 0.0;
+        if let Some(stopped) = inner.stopped {
+            numerator = (inner.current_value - inner.initial_value) as f64;
+            denominator = stopped.duration_since(inner.started).as_secs_f64();
+        } else {
+            match inner.buckets.len() {
+                0 => {}
+                1 => {
+                    numerator = (inner.buckets[0].value - inner.initial_value) as f64;
+                    denominator = inner.buckets[0].updated.duration_since(inner.started).as_secs_f64();
+                }
+                _ => {
+                    let first = &inner.buckets[0];
+                    let last = inner.buckets.last().unwrap();
+                    numerator = (last.value - first.value) as f64;
+                    denominator = last.updated.duration_since(first.updated).as_secs_f64();
+                }
+            }
+        }
+        if denominator != 0.0 { numerator / denominator } else { 0.0 }
+    }
+
+    pub fn to_string(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+        let term = Term::stderr();
+        let (_, term_width) = term.size();
+        let term_width = term_width as usize;
+
+        let mut pre = String::new();
+        if !inner.message.is_empty() {
+            let mut message = inner.message.trim().to_string();
+            if inner.message_width > 0 && message.len() > inner.message_width as usize {
+                message.truncate(inner.message_width as usize);
+            }
+            pre.push_str(&message);
+            if inner.message_width > 0 {
+                let pad = inner.message_width as usize - message.len();
+                if pad > 0 { pre.push_str(&" ".repeat(pad)); }
+            }
+            pre.push(' ');
+        }
+        pre.push_str(&format!("{:>3.0}%", Bar::percent(&inner)));
+
+        let mut suf = String::new();
+        if inner.stopped.is_none() {
+            let cur = human_bytes(inner.current_value);
+            suf.push_str(&" ".repeat(6 - cur.len()));
+            suf.push_str(&cur);
+            suf.push('/');
+            let max = human_bytes(inner.max_value);
+            suf.push_str(&" ".repeat(6 - max.len()));
+            suf.push_str(&max);
+        } else {
+            let max = human_bytes(inner.max_value);
+            suf.push_str(&" ".repeat(6 - max.len()));
+            suf.push_str(&max);
+            suf.push_str(&" ".repeat(7));
+        }
+
+        let rate = Bar::rate(&inner);
+        if inner.stopped.is_none() && rate > 0.0 {
+            suf.push_str("  ");
+            let hr = human_bytes(rate as i64);
+            suf.push_str(&" ".repeat(6 - hr.len()));
+            suf.push_str(&hr);
+            suf.push_str("/s");
+        } else {
+            suf.push_str(&" ".repeat(10));
+        }
+
+        if inner.stopped.is_none() && rate > 0.0 {
+            suf.push_str("  ");
+            let remaining = Duration::from_secs_f64((inner.max_value - inner.current_value) as f64 / rate);
+            let human_rem = format_duration(remaining);
+            suf.push_str(&" ".repeat(6 - human_rem.len()));
+            suf.push_str(&human_rem);
+        } else {
+            suf.push_str(&" ".repeat(8));
+        }
+
+        let mut mid = String::new();
+        let f = term_width as isize - pre.len() as isize - suf.len() as isize - 5;
+        let f = if f > 0 { f as usize } else { 0 };
+        let n = ((f as f64) * Bar::percent(&inner) / 100.0) as usize;
+        mid.push_str(" ▕");
+        if n > 0 { mid.push_str(&"█".repeat(n)); }
+        if f > n { mid.push_str(&" ".repeat(f - n)); }
+        mid.push_str("▏ ");
+
+        format!("{}{}{}", pre, mid, suf)
+    }
+}
+
+impl State for Bar {
+    fn render(&self) -> String {
+        self.to_string()
+    }
+}
+
+fn human_bytes(b: i64) -> String {
+    const KB: i64 = 1000;
+    const MB: i64 = KB * 1000;
+    const GB: i64 = MB * 1000;
+    const TB: i64 = GB * 1000;
+    let (value, unit) = if b >= TB {
+        (b as f64 / TB as f64, "TB")
+    } else if b >= GB {
+        (b as f64 / GB as f64, "GB")
+    } else if b >= MB {
+        (b as f64 / MB as f64, "MB")
+    } else if b >= KB {
+        (b as f64 / KB as f64, "KB")
+    } else {
+        return format!("{} B", b);
+    };
+    if value >= 10.0 {
+        format!("{} {}", value as i64, unit)
+    } else if (value - value.trunc()).abs() > f64::EPSILON {
+        format!("{:.1} {}", value, unit)
+    } else {
+        format!("{} {}", value as i64, unit)
+    }
+}
+
+fn format_duration(d: Duration) -> String {
+    if d >= Duration::from_secs(360000) {
+        "99h+".into()
+    } else if d >= Duration::from_secs(3600) {
+        format!("{}h{}m", d.as_secs() / 3600, (d.as_secs() / 60) % 60)
+    } else {
+        format!("{}s", d.as_secs())
+    }
+}

--- a/rust/progress/src/lib.rs
+++ b/rust/progress/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod bar;
+pub mod spinner;
+mod progress;
+
+pub use bar::Bar;
+pub use progress::{Progress, State};
+pub use spinner::Spinner;
+
+#[cfg(test)]
+mod tests;

--- a/rust/progress/src/progress.rs
+++ b/rust/progress/src/progress.rs
@@ -1,0 +1,71 @@
+use std::sync::{Arc, Mutex};
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
+
+use console::Term;
+
+pub trait State: Send + Sync {
+    fn render(&self) -> String;
+    fn stop(&self) {}
+}
+
+pub struct Progress {
+    term: Term,
+    states: Arc<Mutex<Vec<Arc<dyn State>>>>,
+    ticker_stop: Arc<AtomicBool>,
+    handle: Mutex<Option<thread::JoinHandle<()>>>,
+}
+
+impl Progress {
+    pub fn new() -> Self {
+        let term = Term::stderr();
+        let states: Arc<Mutex<Vec<Arc<dyn State>>>> = Arc::new(Mutex::new(Vec::new()));
+        let stop_flag = Arc::new(AtomicBool::new(false));
+        let states_clone = states.clone();
+        let term_clone = term.clone();
+        let stop_clone = stop_flag.clone();
+        let handle = thread::spawn(move || {
+            while !stop_clone.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(100));
+                render_inner(&term_clone, &states_clone);
+            }
+        });
+        Progress { term, states, ticker_stop: stop_flag, handle: Mutex::new(Some(handle)) }
+    }
+
+    pub fn add<S>(&self, state: Arc<S>)
+    where
+        S: State + 'static,
+    {
+        let mut states = self.states.lock().unwrap();
+        states.push(state as Arc<dyn State>);
+    }
+
+    pub fn stop(&self) -> bool {
+        if self.ticker_stop.swap(true, Ordering::SeqCst) {
+            return false;
+        }
+        if let Some(handle) = self.handle.lock().unwrap().take() {
+            handle.join().ok();
+        }
+        {
+            let states = self.states.lock().unwrap();
+            for s in states.iter() {
+                s.stop();
+            }
+        }
+        render_inner(&self.term, &self.states);
+        let _ = self.term.write_line("");
+        true
+    }
+}
+
+fn render_inner(term: &Term, states: &Arc<Mutex<Vec<Arc<dyn State>>>>) {
+    let states_guard = states.lock().unwrap();
+    if states_guard.is_empty() { return; }
+    let _ = term.clear_last_lines(states_guard.len());
+    for s in states_guard.iter() {
+        let _ = term.write_line(&s.render());
+    }
+}

--- a/rust/progress/src/spinner.rs
+++ b/rust/progress/src/spinner.rs
@@ -1,0 +1,88 @@
+use std::sync::{Arc, RwLock};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::progress::State;
+
+pub struct Spinner {
+    message: Arc<RwLock<String>>,
+    pub message_width: isize,
+    parts: Vec<&'static str>,
+    value: Arc<AtomicUsize>,
+    ticker_stop: Arc<AtomicBool>,
+    started: Instant,
+    stopped: Arc<AtomicBool>,
+}
+
+impl Spinner {
+    pub fn new(message: impl Into<String>) -> Self {
+        let spinner = Spinner {
+            message: Arc::new(RwLock::new(message.into())),
+            message_width: -1,
+            parts: vec!["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"],
+            value: Arc::new(AtomicUsize::new(0)),
+            ticker_stop: Arc::new(AtomicBool::new(false)),
+            started: Instant::now(),
+            stopped: Arc::new(AtomicBool::new(false)),
+        };
+        spinner.start();
+        spinner
+    }
+
+    pub fn set_message(&self, message: impl Into<String>) {
+        let mut lock = self.message.write().unwrap();
+        *lock = message.into();
+    }
+
+    fn start(&self) {
+        let stop = self.ticker_stop.clone();
+        let value = self.value.clone();
+        thread::spawn(move || {
+            while !stop.load(Ordering::SeqCst) {
+                thread::sleep(Duration::from_millis(100));
+                let v = (value.load(Ordering::SeqCst) + 1) % 10;
+                value.store(v, Ordering::SeqCst);
+            }
+        });
+    }
+
+    pub fn stop(&self) {
+        if !self.stopped.swap(true, Ordering::SeqCst) {
+            self.ticker_stop.store(true, Ordering::SeqCst);
+        }
+    }
+
+    pub fn to_string(&self) -> String {
+        let mut sb = String::new();
+        let message = self.message.read().unwrap().clone();
+        if !message.is_empty() {
+            let mut message = message.trim().to_string();
+            if self.message_width > 0 && message.len() > self.message_width as usize {
+                message.truncate(self.message_width as usize);
+            }
+            sb.push_str(&message);
+            if self.message_width > 0 {
+                let pad = self.message_width as usize - message.len();
+                if pad > 0 { sb.push_str(&" ".repeat(pad)); }
+            }
+            sb.push(' ');
+        }
+        if !self.stopped.load(Ordering::SeqCst) {
+            let parts_index = self.value.load(Ordering::SeqCst) % self.parts.len();
+            sb.push_str(self.parts[parts_index]);
+            sb.push(' ');
+        }
+        sb
+    }
+}
+
+impl State for Spinner {
+    fn render(&self) -> String {
+        self.to_string()
+    }
+
+    fn stop(&self) {
+        Spinner::stop(self);
+    }
+}

--- a/rust/progress/src/tests.rs
+++ b/rust/progress/src/tests.rs
@@ -1,0 +1,42 @@
+use super::*;
+use std::sync::Arc;
+use std::thread;
+use std::time::Duration;
+
+#[test]
+fn bar_formatting_contains_percent() {
+    let bar = Bar::new("download", 100, 0);
+    bar.set(50);
+    let out = bar.to_string();
+    assert!(out.contains("50%"));
+    assert!(out.contains("download"));
+}
+
+#[test]
+fn progress_concurrent_usage() {
+    let progress = Progress::new();
+    let bar = Arc::new(Bar::new("task", 100, 0));
+    let spinner = Arc::new(Spinner::new("spin"));
+    progress.add(bar.clone());
+    progress.add(spinner.clone());
+
+    let updater = {
+        let bar = bar.clone();
+        thread::spawn(move || {
+            for i in 0..=100 {
+                bar.set(i);
+                thread::sleep(Duration::from_millis(5));
+            }
+        })
+    };
+
+    thread::sleep(Duration::from_millis(200));
+    assert!(progress.stop());
+    assert!(!progress.stop());
+    updater.join().unwrap();
+
+    let spin_output = spinner.to_string();
+    for part in ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"] {
+        assert!(!spin_output.contains(part));
+    }
+}


### PR DESCRIPTION
## Summary
- add `progress` crate with spinner, progress bar, and manager
- render progress lines using `console` library
- add tests for output formatting and concurrent usage

## Testing
- `cd rust/progress && cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c55abdb898832f8e8acc29069ba1a6