### PR TITLE
Add cross-platform readline crate

### DIFF
--- a/rust/.gitignore
+++ b/rust/.gitignore
@@ -1,1 +1,2 @@
 /target
+**/target

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23,6 +29,31 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "crossterm"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "libc",
+ "mio",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "dirs"
@@ -94,10 +125,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "lock_api"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+
+[[package]]
+name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi",
+ "windows-sys",
+]
 
 [[package]]
 name = "option-ext"
@@ -111,6 +164,30 @@ version = "0.1.0"
 dependencies = [
  "cc",
  "envconfig",
+ "readline",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -132,6 +209,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "readline"
+version = "0.1.0"
+dependencies = [
+ "crossterm",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -143,10 +236,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "syn"
@@ -192,12 +327,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-sys"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -206,13 +363,29 @@ version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -222,10 +395,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -234,10 +419,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -246,13 +449,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 envconfig = { path = "envconfig" }
+readline = { path = "readline" }
 
 [build-dependencies]
 cc = "1.0"

--- a/rust/readline/Cargo.toml
+++ b/rust/readline/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "readline"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+crossterm = "0.27"

--- a/rust/readline/src/lib.rs
+++ b/rust/readline/src/lib.rs
@@ -1,0 +1,387 @@
+use crossterm::event::{self, Event, KeyCode, KeyEvent, KeyModifiers};
+#[cfg(test)]
+use std::collections::VecDeque;
+use std::io;
+
+#[derive(Clone, Debug)]
+pub struct Prompt {
+    pub prompt: String,
+    pub alt_prompt: String,
+    pub placeholder: String,
+    pub alt_placeholder: String,
+    pub use_alt: bool,
+}
+
+impl Default for Prompt {
+    fn default() -> Self {
+        Self {
+            prompt: ">".into(),
+            alt_prompt: ">".into(),
+            placeholder: String::new(),
+            alt_placeholder: String::new(),
+            use_alt: false,
+        }
+    }
+}
+
+impl Prompt {
+    pub fn prompt(&self) -> &str {
+        if self.use_alt {
+            &self.alt_prompt
+        } else {
+            &self.prompt
+        }
+    }
+
+    pub fn placeholder(&self) -> &str {
+        if self.use_alt {
+            &self.alt_placeholder
+        } else {
+            &self.placeholder
+        }
+    }
+}
+
+#[derive(Debug)]
+pub enum ReadlineError {
+    Interrupted,
+    Eof,
+    Io(io::Error),
+}
+
+impl PartialEq for ReadlineError {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (ReadlineError::Interrupted, ReadlineError::Interrupted)
+                | (ReadlineError::Eof, ReadlineError::Eof)
+        )
+    }
+}
+
+impl std::fmt::Display for ReadlineError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReadlineError::Interrupted => write!(f, "interrupted"),
+            ReadlineError::Eof => write!(f, "eof"),
+            ReadlineError::Io(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for ReadlineError {}
+
+pub trait Terminal {
+    fn read(&mut self) -> io::Result<Event>;
+}
+
+pub struct CrosstermTerminal;
+
+impl Terminal for CrosstermTerminal {
+    fn read(&mut self) -> io::Result<Event> {
+        event::read()
+    }
+}
+
+#[cfg(test)]
+pub struct MockTerminal {
+    events: VecDeque<Event>,
+}
+
+#[cfg(test)]
+impl MockTerminal {
+    pub fn new(events: Vec<Event>) -> Self {
+        Self {
+            events: events.into(),
+        }
+    }
+
+    pub fn push(&mut self, events: Vec<Event>) {
+        self.events.extend(events);
+    }
+}
+
+#[cfg(test)]
+impl Terminal for MockTerminal {
+    fn read(&mut self) -> io::Result<Event> {
+        if let Some(ev) = self.events.pop_front() {
+            Ok(ev)
+        } else {
+            Err(io::Error::new(io::ErrorKind::UnexpectedEof, "no events"))
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct Buffer {
+    buf: Vec<char>,
+    pos: usize,
+}
+
+impl Buffer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
+    pub fn add(&mut self, c: char) {
+        self.buf.insert(self.pos, c);
+        self.pos += 1;
+    }
+
+    pub fn remove(&mut self) {
+        if self.pos > 0 {
+            self.pos -= 1;
+            self.buf.remove(self.pos);
+        }
+    }
+
+    pub fn delete(&mut self) {
+        if self.pos < self.buf.len() {
+            self.buf.remove(self.pos);
+        }
+    }
+
+    pub fn move_left(&mut self) {
+        if self.pos > 0 {
+            self.pos -= 1;
+        }
+    }
+
+    pub fn move_right(&mut self) {
+        if self.pos < self.buf.len() {
+            self.pos += 1;
+        }
+    }
+
+    pub fn move_to_start(&mut self) {
+        self.pos = 0;
+    }
+
+    pub fn move_to_end(&mut self) {
+        self.pos = self.buf.len();
+    }
+
+    pub fn replace(&mut self, chars: &[char]) {
+        self.buf = chars.to_vec();
+        self.pos = self.buf.len();
+    }
+
+    pub fn string(&self) -> String {
+        self.buf.iter().collect()
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct History {
+    entries: Vec<String>,
+    pos: usize,
+    pub enabled: bool,
+}
+
+impl History {
+    pub fn new() -> Self {
+        Self {
+            entries: Vec::new(),
+            pos: 0,
+            enabled: true,
+        }
+    }
+
+    pub fn add(&mut self, s: String) {
+        if self.enabled {
+            self.entries.push(s);
+            self.pos = self.entries.len();
+        }
+    }
+
+    pub fn prev(&mut self) -> Option<String> {
+        if self.pos > 0 {
+            self.pos -= 1;
+            Some(self.entries[self.pos].clone())
+        } else {
+            None
+        }
+    }
+
+    pub fn next(&mut self) -> Option<String> {
+        if self.pos < self.entries.len() {
+            self.pos += 1;
+            if self.pos == self.entries.len() {
+                None
+            } else {
+                Some(self.entries[self.pos].clone())
+            }
+        } else {
+            None
+        }
+    }
+
+    pub fn size(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn enable(&mut self) {
+        self.enabled = true;
+    }
+
+    pub fn disable(&mut self) {
+        self.enabled = false;
+    }
+}
+
+pub struct Instance<T: Terminal> {
+    pub prompt: Prompt,
+    pub terminal: T,
+    pub history: History,
+    pub pasting: bool,
+}
+
+impl<T: Terminal> Instance<T> {
+    pub fn new(prompt: Prompt, terminal: T) -> Self {
+        Self {
+            prompt,
+            terminal,
+            history: History::new(),
+            pasting: false,
+        }
+    }
+
+    pub fn readline(&mut self) -> Result<String, ReadlineError> {
+        let mut buf = Buffer::new();
+        loop {
+            let ev = self.terminal.read().map_err(ReadlineError::Io)?;
+            if let Event::Key(KeyEvent {
+                code, modifiers, ..
+            }) = ev
+            {
+                match (code, modifiers) {
+                    (KeyCode::Char('c'), KeyModifiers::CONTROL) => {
+                        return Err(ReadlineError::Interrupted)
+                    }
+                    (KeyCode::Char('d'), KeyModifiers::CONTROL) => {
+                        if buf.is_empty() {
+                            return Err(ReadlineError::Eof);
+                        }
+                    }
+                    (KeyCode::Char(ch), mods) if mods.is_empty() => {
+                        buf.add(ch);
+                    }
+                    (KeyCode::Backspace, _) => {
+                        buf.remove();
+                    }
+                    (KeyCode::Delete, _) => {
+                        if buf.is_empty() {
+                            return Err(ReadlineError::Eof);
+                        }
+                        buf.delete();
+                    }
+                    (KeyCode::Left, _) => buf.move_left(),
+                    (KeyCode::Right, _) => buf.move_right(),
+                    (KeyCode::Up, _) => {
+                        if let Some(line) = self.history.prev() {
+                            let chars: Vec<char> = line.chars().collect();
+                            buf.replace(&chars);
+                        }
+                    }
+                    (KeyCode::Down, _) => {
+                        if let Some(line) = self.history.next() {
+                            let chars: Vec<char> = line.chars().collect();
+                            buf.replace(&chars);
+                        } else {
+                            buf.replace(&[]);
+                        }
+                    }
+                    (KeyCode::Enter, _) => {
+                        let line = buf.string();
+                        if !line.is_empty() {
+                            self.history.add(line.clone());
+                        }
+                        return Ok(line);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    pub fn history_enable(&mut self) {
+        self.history.enable();
+    }
+
+    pub fn history_disable(&mut self) {
+        self.history.disable();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev_char(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE))
+    }
+    fn ev_ctrl(c: char) -> Event {
+        Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::CONTROL))
+    }
+    fn ev(code: KeyCode) -> Event {
+        Event::Key(KeyEvent::new(code, KeyModifiers::NONE))
+    }
+
+    #[test]
+    fn editing_basic() {
+        let events = vec![
+            ev_char('a'),
+            ev(KeyCode::Left),
+            ev_char('b'),
+            ev(KeyCode::Enter),
+        ];
+        let term = MockTerminal::new(events);
+        let prompt = Prompt::default();
+        let mut inst = Instance::new(prompt, term);
+        let line = inst.readline().unwrap();
+        assert_eq!(line, "ba");
+    }
+
+    #[test]
+    fn history_navigation() {
+        let mut term = MockTerminal::new(vec![]);
+        term.push(vec![
+            ev_char('f'),
+            ev_char('o'),
+            ev_char('o'),
+            ev(KeyCode::Enter),
+        ]);
+        let prompt = Prompt::default();
+        let mut inst = Instance::new(prompt, term);
+        let line1 = inst.readline().unwrap();
+        assert_eq!(line1, "foo");
+        inst.terminal
+            .push(vec![ev(KeyCode::Up), ev(KeyCode::Enter)]);
+        let line2 = inst.readline().unwrap();
+        assert_eq!(line2, "foo");
+    }
+
+    #[test]
+    fn ctrl_c_interrupt() {
+        let events = vec![ev_ctrl('c')];
+        let term = MockTerminal::new(events);
+        let prompt = Prompt::default();
+        let mut inst = Instance::new(prompt, term);
+        let err = inst.readline().unwrap_err();
+        assert_eq!(err, ReadlineError::Interrupted);
+    }
+
+    #[test]
+    fn ctrl_d_eof() {
+        let events = vec![ev_ctrl('d')];
+        let term = MockTerminal::new(events);
+        let prompt = Prompt::default();
+        let mut inst = Instance::new(prompt, term);
+        let err = inst.readline().unwrap_err();
+        assert_eq!(err, ReadlineError::Eof);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `readline` crate providing prompt, buffer, and history abstractions
- integrate crossterm-based event loop for cross-platform line editing
- include tests for editing, history navigation, and error handling

## Testing
- `CARGO_TARGET_DIR=rust/target cargo test --manifest-path rust/readline/Cargo.toml`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c5755ed768832fb2a4a65425e27b01