### PR TITLE
Enable compute-weighted multi-GPU scheduling

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -149,6 +149,24 @@ func Bool(k string) func() bool {
 	}
 }
 
+// BoolDefault returns the value of the environment variable as a bool.
+// If the variable is unset or cannot be parsed, it returns the provided
+// default value.
+func BoolDefault(k string, def bool) func() bool {
+	return func() bool {
+		if s := Var(k); s != "" {
+			b, err := strconv.ParseBool(s)
+			if err != nil {
+				return true
+			}
+
+			return b
+		}
+
+		return def
+	}
+}
+
 // LogLevel returns the log level for the application.
 // Values are 0 or false INFO (Default), 1 or true DEBUG, 2 TRACE
 func LogLevel() slog.Level {
@@ -174,7 +192,8 @@ var (
 	// NoPrune disables pruning of model blobs on startup.
 	NoPrune = Bool("OLLAMA_NOPRUNE")
 	// SchedSpread allows scheduling models across all GPUs.
-	SchedSpread = Bool("OLLAMA_SCHED_SPREAD")
+	// Default to true so available GPUs are utilized by default.
+	SchedSpread = BoolDefault("OLLAMA_SCHED_SPREAD", true)
 	// IntelGPU enables experimental Intel GPU detection.
 	IntelGPU = Bool("OLLAMA_INTEL_GPU")
 	// MultiUserCache optimizes prompt caching for multi-user scenarios

--- a/llm/server.go
+++ b/llm/server.go
@@ -974,6 +974,31 @@ nextLayer:
 
 // assignLayers packs the maximum number of layers onto the smallest set of GPUs and comes up with a layer assignment
 func assignLayers(layers []uint64, gpus discover.GpuInfoList, requestedLayers int, lastUsedGPU int) (gpuLayers ml.GPULayersList) {
+	// Adjust GPU free memory by relative compute capability so that more
+	// powerful GPUs receive a larger portion of the workload. Compute
+	// capability is parsed from the GPU information and normalized to the
+	// most capable device.
+	if len(gpus) > 0 {
+		scores := make([]float64, len(gpus))
+		maxScore := 0.0
+		for i, g := range gpus {
+			scores[i] = gpuComputeScore(g)
+			if scores[i] > maxScore {
+				maxScore = scores[i]
+			}
+		}
+		if maxScore > 0 {
+			for i := range gpus {
+				// scale between 50% and 100% of available memory
+				factor := 0.5
+				if scores[i] > 0 {
+					factor += 0.5 * (scores[i] / maxScore)
+				}
+				gpus[i].FreeMemory = uint64(float64(gpus[i].FreeMemory) * factor)
+			}
+		}
+	}
+
 	// If we can't fit everything then prefer offloading layers other than the output layer
 	for range 2 {
 		// requestedLayers may be -1 if nothing was requested
@@ -1002,6 +1027,24 @@ func assignLayers(layers []uint64, gpus discover.GpuInfoList, requestedLayers in
 	}
 
 	return gpuLayers
+}
+
+// gpuComputeScore attempts to parse a numeric compute capability from the GPU
+// info. It supports plain floats like "8.6" as well as strings prefixed with
+// "gfx". If parsing fails, zero is returned.
+func gpuComputeScore(g discover.GpuInfo) float64 {
+	if g.Compute == "" {
+		return 0
+	}
+	if v, err := strconv.ParseFloat(g.Compute, 64); err == nil {
+		return v
+	}
+	if strings.HasPrefix(g.Compute, "gfx") {
+		if n, err := strconv.Atoi(strings.TrimPrefix(g.Compute, "gfx")); err == nil {
+			return float64(n)
+		}
+	}
+	return 0
 }
 
 // findBestFit binary searches to find the smallest capacity factor that can fit

--- a/llm/server_test.go
+++ b/llm/server_test.go
@@ -18,6 +18,7 @@ func TestLLMServerFitGPU(t *testing.T) {
 	type gpu struct {
 		library string
 		free    int
+		compute string
 	}
 
 	tests := []struct {
@@ -92,6 +93,13 @@ func TestLLMServerFitGPU(t *testing.T) {
 			expected: ml.GPULayersList{{ID: "gpu1", Layers: []int{1}}},
 		},
 		{
+			name:     "Multi GPU compute weighted",
+			gpus:     []gpu{{free: 200 * format.MebiByte, compute: "5"}, {free: 200 * format.MebiByte, compute: "1"}},
+			layers:   []int{100 * format.MebiByte, 100 * format.MebiByte, 100 * format.MebiByte},
+			numGPU:   -1,
+			expected: ml.GPULayersList{{ID: "gpu0", Layers: []int{0, 1}}, {ID: "gpu1", Layers: []int{2}}},
+		},
+		{
 			name:     "Multi GPU numGPU 1",
 			gpus:     []gpu{{free: 128 * format.MebiByte}, {free: 256 * format.MebiByte}},
 			layers:   []int{50 * format.MebiByte, 50 * format.MebiByte, 50 * format.MebiByte},
@@ -129,6 +137,8 @@ func TestLLMServerFitGPU(t *testing.T) {
 		},
 	}
 
+	t.Setenv("OLLAMA_SCHED_SPREAD", "false")
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			var systemInfo discover.SystemInfo
@@ -141,6 +151,7 @@ func TestLLMServerFitGPU(t *testing.T) {
 				gpus[i].ID = fmt.Sprintf("gpu%d", i)
 				gpus[i].Library = tt.gpus[i].library
 				gpus[i].FreeMemory = uint64(tt.gpus[i].free)
+				gpus[i].Compute = tt.gpus[i].compute
 			}
 
 			s := &ollamaServer{


### PR DESCRIPTION
## Summary
- use all detected GPUs by default
- distribute layers using GPU compute capability weighting
- add tests for compute-aware layer assignments

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68c577705c24832fb6ee26b7e23c4b46