### PR TITLE
feat(rust): add OpenAI-compatible endpoints

### DIFF
--- a/docs/openai.md
+++ b/docs/openai.md
@@ -366,3 +366,30 @@ curl http://localhost:11434/v1/chat/completions \
         ]
     }'
 ```
+
+### Rust example
+
+```rust
+use api::openai::{ChatCompletionRequest, Message};
+use api::Client;
+use reqwest::Method;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::from_env()?;
+    let req = ChatCompletionRequest {
+        model: "llama3.1".into(),
+        messages: vec![Message {
+            role: "user".into(),
+            content: serde_json::Value::String("Hello".into()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let resp: serde_json::Value = client
+        .do_request(Method::POST, "/v1/chat/completions", Some(&req))
+        .await?;
+    println!("{resp}");
+    Ok(())
+}
+```

--- a/rust/api/Cargo.lock
+++ b/rust/api/Cargo.lock
@@ -21,12 +21,14 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 name = "api"
 version = "0.1.0"
 dependencies = [
+ "base64",
  "futures-util",
  "humantime",
  "ollama_types",
  "reqwest",
  "serde",
  "serde_json",
+ "time",
  "tiny_http",
  "tokio",
  "url",
@@ -120,6 +122,15 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
+]
 
 [[package]]
 name = "displaydoc"
@@ -550,6 +561,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -597,6 +614,12 @@ checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "proc-macro2"
@@ -867,6 +890,36 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]

--- a/rust/api/Cargo.toml
+++ b/rust/api/Cargo.toml
@@ -12,6 +12,8 @@ humantime = "2"
 futures-util = "0.3"
 ollama_types = { path = "../ollama_types" }
 url = "2.5"
+base64 = "0.21"
+time = { version = "0.3", features = ["parsing"] }
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/rust/api/examples/openai_chat.rs
+++ b/rust/api/examples/openai_chat.rs
@@ -1,0 +1,29 @@
+use api::openai::{ChatCompletionRequest, Message};
+use api::Client;
+use reqwest::Method;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Create client pointing at the local Ollama server
+    let client = Client::from_env()?;
+
+    // Build an OpenAI compatible chat completion request
+    let req = ChatCompletionRequest {
+        model: "llama3.1".into(),
+        messages: vec![Message {
+            role: "user".into(),
+            content: serde_json::Value::String("Hello".into()),
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Send request to the OpenAI compatible endpoint
+    let resp: serde_json::Value = client
+        .do_request(Method::POST, "/v1/chat/completions", Some(&req))
+        .await?;
+
+    println!("{resp}");
+    Ok(())
+}
+

--- a/rust/api/src/lib.rs
+++ b/rust/api/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod client;
 pub mod types;
+pub mod openai;
 
 pub use client::Client;
 pub use types::*;

--- a/rust/api/src/openai.rs
+++ b/rust/api/src/openai.rs
@@ -1,0 +1,537 @@
+use std::collections::HashMap;
+
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use time::OffsetDateTime;
+
+use crate::types::{self as api, Message as ApiMessage};
+use ollama_types::model::parse_name;
+
+/// Error information returned to OpenAI compatible clients.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct Error {
+    pub message: String,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub param: Option<Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct ErrorResponse {
+    pub error: Error,
+}
+
+/// Helper to create an `ErrorResponse` similar to the Go implementation.
+pub fn new_error(message: &str) -> ErrorResponse {
+    ErrorResponse {
+        error: Error {
+            message: message.to_string(),
+            type_field: "invalid_request_error".to_string(),
+            code: None,
+            param: None,
+        },
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct StreamOptions {
+    #[serde(default)]
+    pub include_usage: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct JsonSchema {
+    pub schema: Value,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ResponseFormat {
+    #[serde(rename = "type", default)]
+    pub type_field: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub json_schema: Option<JsonSchema>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Reasoning {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ToolCallFunction {
+    pub name: String,
+    pub arguments: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub index: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ToolCall {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub id: Option<String>,
+    #[serde(rename = "type")]
+    pub type_field: String,
+    pub function: ToolCallFunction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Message {
+    pub role: String,
+    #[serde(default)]
+    pub content: Value,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty", rename = "tool_calls")]
+    pub tool_calls: Vec<ToolCall>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "tool_call_id")]
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<Message>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default, rename = "frequency_penalty", skip_serializing_if = "Option::is_none")]
+    pub frequency_penalty: Option<f64>,
+    #[serde(default, rename = "presence_penalty", skip_serializing_if = "Option::is_none")]
+    pub presence_penalty: Option<f64>,
+    #[serde(default, rename = "top_p", skip_serializing_if = "Option::is_none")]
+    pub top_p: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<ResponseFormat>,
+    #[serde(default)]
+    pub tools: Vec<api::Tool>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<Reasoning>,
+    #[serde(default, rename = "reasoning_effort", skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CompletionRequest {
+    pub model: String,
+    pub prompt: String,
+    #[serde(default)]
+    pub frequency_penalty: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<i32>,
+    #[serde(default)]
+    pub presence_penalty: f64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub seed: Option<i32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stop: Option<Value>,
+    #[serde(default)]
+    pub stream: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(default)]
+    pub top_p: f64,
+    #[serde(default)]
+    pub suffix: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct EmbedRequest {
+    #[serde(default)]
+    pub input: Value,
+    pub model: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dimensions: Option<i32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct Model {
+    pub id: String,
+    pub object: String,
+    pub created: i64,
+    #[serde(rename = "owned_by")]
+    pub owned_by: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+pub struct ListCompletion {
+    pub object: String,
+    pub data: Option<Vec<Model>>,
+}
+
+/// Convert chat completion request into an internal [`api::ChatRequest`].
+pub fn from_chat_request(r: ChatCompletionRequest) -> Result<api::ChatRequest, ErrorResponse> {
+    let mut messages: Vec<ApiMessage> = Vec::new();
+
+    for msg in r.messages.iter() {
+        let mut tool_name = String::new();
+        if msg.role.eq_ignore_ascii_case("tool") {
+            if let Some(n) = &msg.name {
+                tool_name = n.clone();
+            } else if let Some(id) = &msg.tool_call_id {
+                tool_name = name_from_tool_call_id(&r.messages, id);
+            }
+        }
+
+        match &msg.content {
+            Value::String(s) => {
+                let tool_calls = from_completion_tool_calls(&msg.tool_calls)?;
+                messages.push(ApiMessage {
+                    role: msg.role.clone(),
+                    content: s.clone(),
+                    thinking: msg.reasoning.clone().unwrap_or_default(),
+                    images: Vec::new(),
+                    tool_calls,
+                    tool_name,
+                });
+            }
+            Value::Array(arr) => {
+                for c in arr {
+                    let data = c.as_object().ok_or_else(|| new_error("invalid message format"))?;
+                    match data.get("type").and_then(|v| v.as_str()) {
+                        Some("text") => {
+                            let text = data
+                                .get("text")
+                                .and_then(|v| v.as_str())
+                                .ok_or_else(|| new_error("invalid message format"))?;
+                            messages.push(ApiMessage {
+                                role: msg.role.clone(),
+                                content: text.to_string(),
+                                thinking: String::new(),
+                                images: Vec::new(),
+                                tool_calls: Vec::new(),
+                                tool_name: String::new(),
+                            });
+                        }
+                        Some("image_url") => {
+                            let url_val = data.get("image_url").ok_or_else(|| new_error("invalid message format"))?;
+                            let url = if let Some(m) = url_val.as_object() {
+                                m.get("url").and_then(|v| v.as_str()).ok_or_else(|| new_error("invalid message format"))?
+                            } else {
+                                url_val.as_str().ok_or_else(|| new_error("invalid message format"))?
+                            };
+
+                            let mut valid = false;
+                            let mut b64 = String::new();
+                            for t in ["jpeg", "jpg", "png", "webp"] {
+                                let prefix = format!("data:image/{};base64,", t);
+                                if let Some(rest) = url.strip_prefix(&prefix) {
+                                    valid = true;
+                                    b64 = rest.to_string();
+                                    break;
+                                }
+                            }
+                            if !valid {
+                                return Err(new_error("invalid image input"));
+                            }
+                            let img = BASE64
+                                .decode(b64.as_bytes())
+                                .map_err(|_| new_error("invalid message format"))?;
+                            messages.push(ApiMessage {
+                                role: msg.role.clone(),
+                                content: String::new(),
+                                thinking: String::new(),
+                                images: vec![img],
+                                tool_calls: Vec::new(),
+                                tool_name: String::new(),
+                            });
+                        }
+                        _ => return Err(new_error("invalid message format")),
+                    }
+                }
+                if !messages.is_empty() && !msg.tool_calls.is_empty() {
+                    let tool_calls = from_completion_tool_calls(&msg.tool_calls)?;
+                    if let Some(last) = messages.last_mut() {
+                        last.tool_calls = tool_calls;
+                        last.tool_name = tool_name;
+                        if let Some(r) = &msg.reasoning {
+                            last.thinking = r.clone();
+                        }
+                    }
+                }
+            }
+            Value::Null => {
+                if msg.tool_calls.is_empty() {
+                    return Err(new_error(&format!(
+                        "invalid message content type: {:?}",
+                        msg.content
+                    )));
+                }
+                let tool_calls = from_completion_tool_calls(&msg.tool_calls)?;
+                messages.push(ApiMessage {
+                    role: msg.role.clone(),
+                    content: String::new(),
+                    thinking: msg.reasoning.clone().unwrap_or_default(),
+                    images: Vec::new(),
+                    tool_calls,
+                    tool_name,
+                });
+            }
+            other => {
+                if msg.tool_calls.is_empty() {
+                    return Err(new_error(&format!("invalid message content type: {}", value_type(other))));
+                }
+                let tool_calls = from_completion_tool_calls(&msg.tool_calls)?;
+                messages.push(ApiMessage {
+                    role: msg.role.clone(),
+                    content: String::new(),
+                    thinking: msg.reasoning.clone().unwrap_or_default(),
+                    images: Vec::new(),
+                    tool_calls,
+                    tool_name,
+                });
+            }
+        }
+    }
+
+    let mut options: HashMap<String, Value> = HashMap::new();
+    if let Some(stop) = r.stop {
+        match stop {
+            Value::String(s) => {
+                options.insert("stop".into(), Value::Array(vec![Value::String(s)]));
+            }
+            Value::Array(arr) => {
+                let mut stops = Vec::new();
+                for s in arr {
+                    if let Value::String(st) = s {
+                        stops.push(Value::String(st));
+                    }
+                }
+                options.insert("stop".into(), Value::Array(stops));
+            }
+            _ => {}
+        }
+    }
+
+    if let Some(m) = r.max_tokens {
+        options.insert("num_predict".into(), Value::from(m));
+    }
+    options.insert(
+        "temperature".into(),
+        Value::from(r.temperature.unwrap_or(1.0)),
+    );
+    if let Some(seed) = r.seed {
+        options.insert("seed".into(), Value::from(seed));
+    }
+    if let Some(fp) = r.frequency_penalty {
+        options.insert("frequency_penalty".into(), Value::from(fp));
+    }
+    if let Some(pp) = r.presence_penalty {
+        options.insert("presence_penalty".into(), Value::from(pp));
+    }
+    options.insert("top_p".into(), Value::from(r.top_p.unwrap_or(1.0)));
+
+    let mut format: Option<Value> = None;
+    if let Some(rf) = &r.response_format {
+        match rf.type_field.trim().to_lowercase().as_str() {
+            "json_object" => format = Some(Value::String("json".into())),
+            "json_schema" => {
+                if let Some(js) = &rf.json_schema {
+                    format = Some(js.schema.clone());
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let think = if let Some(rs) = &r.reasoning {
+        rs.effort.clone().map(|v| api::ThinkValue::Str(v))
+    } else if let Some(re) = &r.reasoning_effort {
+        Some(api::ThinkValue::Str(re.clone()))
+    } else {
+        None
+    };
+
+    Ok(api::ChatRequest {
+        model: r.model,
+        messages,
+        stream: Some(r.stream),
+        format,
+        keep_alive: None,
+        tools: r.tools,
+        options,
+        think,
+        debug_render_only: false,
+    })
+}
+
+fn value_type(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn from_completion_tool_calls(tool_calls: &[ToolCall]) -> Result<Vec<api::ToolCall>, ErrorResponse> {
+    let mut out = Vec::new();
+    for tc in tool_calls {
+        let mut args: HashMap<String, Value> = HashMap::new();
+        if !tc.function.arguments.is_empty() {
+            args = serde_json::from_str(&tc.function.arguments)
+                .map_err(|_| new_error("invalid tool call arguments"))?;
+        }
+        out.push(api::ToolCall {
+            function: api::ToolCallFunction {
+                index: tc.function.index,
+                name: tc.function.name.clone(),
+                arguments: args,
+            },
+        });
+    }
+    Ok(out)
+}
+
+fn name_from_tool_call_id(messages: &[Message], id: &str) -> String {
+    for msg in messages.iter().rev() {
+        for tc in &msg.tool_calls {
+            if let Some(tc_id) = &tc.id {
+                if tc_id == id {
+                    return tc.function.name.clone();
+                }
+            }
+        }
+    }
+    String::new()
+}
+
+/// Convert a completion request to [`api::GenerateRequest`].
+pub fn from_completion_request(
+    r: CompletionRequest,
+) -> Result<api::GenerateRequest, ErrorResponse> {
+    let mut options: HashMap<String, Value> = HashMap::new();
+
+    if let Some(stop) = r.stop {
+        match stop {
+            Value::String(s) => {
+                options.insert("stop".into(), Value::Array(vec![Value::String(s)]));
+            }
+            Value::Array(arr) => {
+                let mut stops = Vec::new();
+                for s in arr {
+                    if let Value::String(st) = s {
+                        stops.push(Value::String(st));
+                    } else {
+                        return Err(new_error("invalid type for 'stop' field"));
+                    }
+                }
+                options.insert("stop".into(), Value::Array(stops));
+            }
+            other => return Err(new_error(&format!("invalid type for 'stop' field: {}", value_type(&other)))),
+        }
+    }
+
+    if let Some(m) = r.max_tokens {
+        options.insert("num_predict".into(), Value::from(m));
+    }
+
+    options.insert(
+        "temperature".into(),
+        Value::from(r.temperature.unwrap_or(1.0)),
+    );
+
+    if let Some(seed) = r.seed {
+        options.insert("seed".into(), Value::from(seed));
+    }
+
+    options.insert(
+        "frequency_penalty".into(),
+        Value::from(r.frequency_penalty),
+    );
+    options.insert(
+        "presence_penalty".into(),
+        Value::from(r.presence_penalty),
+    );
+    options.insert("top_p".into(), Value::from(if r.top_p != 0.0 { r.top_p } else { 1.0 }));
+
+    Ok(api::GenerateRequest {
+        model: r.model,
+        prompt: r.prompt,
+        suffix: r.suffix,
+        stream: Some(r.stream),
+        options,
+        ..Default::default()
+    })
+}
+
+/// Validate and convert an embedding creation request.
+pub fn from_embed_request(r: EmbedRequest) -> Result<api::EmbedRequest, ErrorResponse> {
+    if r.input.is_null() {
+        return Err(new_error("invalid input"));
+    }
+    Ok(api::EmbedRequest {
+        model: r.model,
+        input: r.input,
+        dimensions: r.dimensions.unwrap_or_default(),
+        keep_alive: None,
+        truncate: None,
+        options: HashMap::new(),
+    })
+}
+
+/// Convert a [`api::ListResponse`] into an OpenAI compatible model list.
+pub fn to_list_completion(r: api::ListResponse) -> ListCompletion {
+    let mut data = Vec::new();
+    for m in r.models {
+        let created = OffsetDateTime::parse(
+            &m.modified_at,
+            &time::format_description::well_known::Rfc3339,
+        )
+        .map(|t| t.unix_timestamp())
+        .unwrap_or(0);
+        let name = parse_name(&m.name);
+        data.push(Model {
+            id: m.name,
+            object: "model".into(),
+            created,
+            owned_by: name.namespace,
+        });
+    }
+
+    ListCompletion {
+        object: "list".into(),
+        data: if data.is_empty() { None } else { Some(data) },
+    }
+}
+
+/// Convert a [`api::ShowResponse`] into an OpenAI model description.
+pub fn to_model(r: api::ShowResponse, model: &str) -> Model {
+    let created = r
+        .modified_at
+        .as_ref()
+        .and_then(|s| {
+            OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+                .ok()
+                .map(|t| t.unix_timestamp())
+        })
+        .unwrap_or(0);
+    let name = parse_name(model);
+    Model {
+        id: model.to_string(),
+        object: "model".into(),
+        created,
+        owned_by: name.namespace,
+    }
+}
+

--- a/rust/api/src/types.rs
+++ b/rust/api/src/types.rs
@@ -164,12 +164,12 @@ impl<'de> Deserialize<'de> for PropertyType {
 }
 
 // ------------ Tool related ------------
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolCall {
     pub function: ToolCallFunction,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct ToolCallFunction {
     #[serde(default)]
     pub index: Option<i32>,
@@ -264,7 +264,7 @@ pub struct ToolProperty {
 }
 
 // ------------ Message ------------
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize, Default, PartialEq)]
 pub struct Message {
     pub role: String,
     pub content: String,

--- a/rust/api/tests/openai_test.rs
+++ b/rust/api/tests/openai_test.rs
@@ -1,0 +1,274 @@
+use api::openai::*;
+use api as api;
+use serde_json::json;
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine;
+
+const PREFIX: &str = "data:image/jpeg;base64,";
+const IMAGE: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+#[test]
+fn test_from_chat_request() {
+    #[derive(Debug)]
+    struct Case {
+        body: String,
+        req: Option<api::ChatRequest>,
+        err: Option<ErrorResponse>,
+    }
+
+    let false_v = Some(false);
+    let true_v = Some(true);
+
+    let cases = vec![
+        Case {
+            body: r#"{"model":"test-model","messages":[{"role":"user","content":"Hello"}]}"#.to_string(),
+            req: Some(api::ChatRequest {
+                model: "test-model".into(),
+                messages: vec![api::Message {
+                    role: "user".into(),
+                    content: "Hello".into(),
+                    ..Default::default()
+                }],
+                stream: false_v,
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("temperature".into(), json!(1.0));
+                    m.insert("top_p".into(), json!(1.0));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: r#"{"model":"test-model","messages":[{"role":"user","content":"Hello"}],"stream":true,"max_tokens":999,"seed":123,"stop":["\n","stop"],"temperature":3.0,"frequency_penalty":4.0,"presence_penalty":5.0,"top_p":6.0,"response_format":{"type":"json_object"}}"#.to_string(),
+            req: Some(api::ChatRequest {
+                model: "test-model".into(),
+                messages: vec![api::Message {
+                    role: "user".into(),
+                    content: "Hello".into(),
+                    ..Default::default()
+                }],
+                stream: true_v,
+                format: Some(json!("json")),
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("num_predict".into(), json!(999));
+                    m.insert("seed".into(), json!(123));
+                    m.insert("stop".into(), json!(["\n","stop"]));
+                    m.insert("temperature".into(), json!(3.0));
+                    m.insert("frequency_penalty".into(), json!(4.0));
+                    m.insert("presence_penalty".into(), json!(5.0));
+                    m.insert("top_p".into(), json!(6.0));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: format!(
+                r#"{{"model":"test-model","messages":[{{"role":"user","content":[{{"type":"text","text":"Hello"}},{{"type":"image_url","image_url":"{}{}"}}]}}]}}"#,
+                PREFIX, IMAGE
+            ),
+            req: Some(api::ChatRequest {
+                model: "test-model".into(),
+                messages: vec![
+                    api::Message {
+                        role: "user".into(),
+                        content: "Hello".into(),
+                        ..Default::default()
+                    },
+                    api::Message {
+                        role: "user".into(),
+                        content: String::new(),
+                        images: vec![BASE64.decode(IMAGE).unwrap()],
+                        ..Default::default()
+                    },
+                ],
+                stream: false_v,
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("temperature".into(), json!(1.0));
+                    m.insert("top_p".into(), json!(1.0));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: r#"{"model":"test-model","messages":[{"role":"user","content":"What's the weather?"},{"role":"assistant","tool_calls":[{"id":"id","type":"function","function":{"name":"get_weather","arguments":"{\"location\":\"Paris\"}"}}]}]}"#.to_string(),
+            req: Some(api::ChatRequest {
+                model: "test-model".into(),
+                messages: vec![
+                    api::Message {
+                        role: "user".into(),
+                        content: "What's the weather?".into(),
+                        ..Default::default()
+                    },
+                    api::Message {
+                        role: "assistant".into(),
+                        tool_calls: vec![api::ToolCall {
+                            function: api::ToolCallFunction {
+                                index: None,
+                                name: "get_weather".into(),
+                                arguments: {
+                                    let mut m = std::collections::HashMap::new();
+                                    m.insert("location".into(), json!("Paris"));
+                                    m
+                                },
+                            },
+                        }],
+                        ..Default::default()
+                    },
+                ],
+                stream: false_v,
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("temperature".into(), json!(1.0));
+                    m.insert("top_p".into(), json!(1.0));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: r#"{"model":"test-model","messages":[{"role":"user","content":2}]}"#.to_string(),
+            req: None,
+            err: Some(new_error("invalid message content type: number")),
+        },
+    ];
+
+    for case in cases {
+        let req: ChatCompletionRequest = serde_json::from_str(&case.body).unwrap();
+        match from_chat_request(req) {
+            Ok(actual) => {
+                let expected = case.req.unwrap();
+                assert_eq!(expected.model, actual.model, "model mismatch");
+                assert_eq!(expected.messages, actual.messages);
+            }
+            Err(err) => {
+                assert_eq!(case.err.unwrap(), err);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_from_completion_request() {
+    #[derive(Debug)]
+    struct Case {
+        body: &'static str,
+        req: Option<api::GenerateRequest>,
+        err: Option<ErrorResponse>,
+    }
+
+    let false_v = Some(false);
+    let true_v = Some(true);
+
+    let cases = vec![
+        Case {
+            body: r#"{"model":"test-model","prompt":"Hello","temperature":0.8,"stop":["\n","stop"],"suffix":"suffix"}"#,
+            req: Some(api::GenerateRequest {
+                model: "test-model".into(),
+                prompt: "Hello".into(),
+                suffix: "suffix".into(),
+                stream: false_v,
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("frequency_penalty".into(), json!(0.0));
+                    m.insert("presence_penalty".into(), json!(0.0));
+                    m.insert("temperature".into(), json!(0.8));
+                    m.insert("top_p".into(), json!(1.0));
+                    m.insert("stop".into(), json!(["\n","stop"]));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: r#"{"model":"test-model","prompt":"Hello","stream":true,"temperature":0.8,"stop":["\n","stop"],"suffix":"suffix"}"#,
+            req: Some(api::GenerateRequest {
+                model: "test-model".into(),
+                prompt: "Hello".into(),
+                suffix: "suffix".into(),
+                stream: true_v,
+                options: {
+                    let mut m = std::collections::HashMap::new();
+                    m.insert("frequency_penalty".into(), json!(0.0));
+                    m.insert("presence_penalty".into(), json!(0.0));
+                    m.insert("temperature".into(), json!(0.8));
+                    m.insert("top_p".into(), json!(1.0));
+                    m.insert("stop".into(), json!(["\n","stop"]));
+                    m
+                },
+                ..Default::default()
+            }),
+            err: None,
+        },
+        Case {
+            body: r#"{"model":"test-model","prompt":"Hello","temperature":null,"stop":[1,2],"suffix":"suffix"}"#,
+            req: None,
+            err: Some(new_error("invalid type for 'stop' field")),
+        },
+    ];
+
+    for case in cases {
+        let req: CompletionRequest = serde_json::from_str(case.body).unwrap();
+        match from_completion_request(req) {
+            Ok(actual) => {
+                let expected = case.req.unwrap();
+                assert_eq!(expected.model, actual.model);
+                assert_eq!(expected.prompt, actual.prompt);
+                assert_eq!(expected.options, actual.options);
+            }
+            Err(err) => {
+                assert_eq!(case.err.unwrap(), err);
+            }
+        }
+    }
+}
+
+#[test]
+fn test_from_embed_request() {
+    let ok_body = r#"{"input":"Hello","model":"test-model"}"#;
+    let req: EmbedRequest = serde_json::from_str(ok_body).unwrap();
+    let out = from_embed_request(req).unwrap();
+    assert_eq!(out.input, json!("Hello"));
+
+    let err_body = r#"{"model":"test-model"}"#;
+    let req: EmbedRequest = serde_json::from_str(err_body).unwrap();
+    match from_embed_request(req) {
+        Err(e) => assert_eq!(e, new_error("invalid input")),
+        Ok(_) => panic!("expected error"),
+    }
+}
+
+#[test]
+fn test_to_list_and_model() {
+    let list = api::ListResponse {
+        models: vec![api::ListModelResponse {
+            name: "test-model".into(),
+            model: "test-model".into(),
+            modified_at: "2023-06-16T00:03:22Z".into(),
+            size: 0,
+            digest: String::new(),
+            details: Default::default(),
+        }],
+    };
+    let lc = to_list_completion(list);
+    assert_eq!(lc.object, "list");
+    assert_eq!(lc.data.unwrap()[0].id, "test-model");
+
+    let show = api::ShowResponse {
+        modified_at: Some("2023-06-16T00:03:22Z".into()),
+        ..Default::default()
+    };
+    let m = to_model(show, "test-model");
+    assert_eq!(m.id, "test-model");
+    assert_eq!(m.object, "model");
+}
+


### PR DESCRIPTION
## Summary
- implement OpenAI request/response structures and converters in Rust
- add Rust example for calling OpenAI chat completions
- document OpenAI usage and add parity tests

## Testing
- `cd rust/api && cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c5a0982e24832fa59c3400f882634e