### PR TITLE
Add Rust ml crate with basic neural network modules

### DIFF
--- a/rust/ml/Cargo.toml
+++ b/rust/ml/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "ml"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ndarray = "0.15"

--- a/rust/ml/src/attention.rs
+++ b/rust/ml/src/attention.rs
@@ -1,0 +1,35 @@
+use ndarray::{Array2, Axis};
+
+/// Simple scaled dot-product attention implementation using `ndarray`.
+///
+/// `query`, `key` and `value` are all matrices where the first axis is the
+/// sequence dimension and the second axis is the feature dimension.
+pub fn scaled_dot_product_attention(
+    query: &Array2<f32>,
+    key: &Array2<f32>,
+    value: &Array2<f32>,
+    scale: f32,
+) -> Array2<f32> {
+    let mut scores = query.dot(&key.t());
+    scores *= scale;
+    // softmax along last axis
+    scores.mapv_inplace(|x| x.exp());
+    let sums = scores.sum_axis(Axis(1)).insert_axis(Axis(1));
+    let probs = scores / &sums;
+    probs.dot(value)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_attention_shapes() {
+        let q = array![[1., 0.]]; // (1,2)
+        let k = array![[1., 0.], [0., 1.]]; // (2,2)
+        let v = array![[1., 2.], [3., 4.]]; // (2,2)
+        let out = scaled_dot_product_attention(&q, &k, &v, 1.0);
+        assert_eq!(out.shape(), &[1, 2]);
+    }
+}

--- a/rust/ml/src/backend.rs
+++ b/rust/ml/src/backend.rs
@@ -1,0 +1,51 @@
+use ndarray::Array2;
+
+/// Trait representing basic tensor operations needed by the layers.
+pub trait TensorBackend {
+    fn matmul(&self, a: &Array2<f32>, b: &Array2<f32>) -> Array2<f32>;
+}
+
+/// Backend implemented with the `ndarray` crate.
+#[derive(Default, Clone, Copy)]
+pub struct NdArrayBackend;
+
+impl TensorBackend for NdArrayBackend {
+    fn matmul(&self, a: &Array2<f32>, b: &Array2<f32>) -> Array2<f32> {
+        a.dot(b)
+    }
+}
+
+/// Supported backend variants.
+#[derive(Clone, Copy, Debug)]
+pub enum Backend {
+    NdArray,
+}
+
+impl Backend {
+    /// Construct a backend instance.
+    pub fn build(self) -> Box<dyn TensorBackend> {
+        match self {
+            Backend::NdArray => Box::new(NdArrayBackend::default()),
+        }
+    }
+
+    /// Default backend used when none is specified.
+    pub fn default() -> Self {
+        Backend::NdArray
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_backend_matmul() {
+        let backend = NdArrayBackend::default();
+        let a = array![[1., 2.]];
+        let b = array![[3.], [4.]];
+        let out = backend.matmul(&a, &b);
+        assert_eq!(out, array![[11.]]);
+    }
+}

--- a/rust/ml/src/convolution.rs
+++ b/rust/ml/src/convolution.rs
@@ -1,0 +1,35 @@
+use ndarray::{Array2, s};
+
+/// A very small 2D convolution helper without padding or stride.
+pub fn conv2d(input: &Array2<f32>, kernel: &Array2<f32>) -> Array2<f32> {
+    let (h, w) = input.dim();
+    let (kh, kw) = kernel.dim();
+    let out_h = h - kh + 1;
+    let out_w = w - kw + 1;
+    let mut output = Array2::zeros((out_h, out_w));
+    for i in 0..out_h {
+        for j in 0..out_w {
+            let window = input.slice(s![i..i + kh, j..j + kw]);
+            output[(i, j)] = (&window * kernel).sum();
+        }
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_conv2d() {
+        let input = array![
+            [1., 2., 3.],
+            [4., 5., 6.],
+            [7., 8., 9.]
+        ];
+        let kernel = array![[1., 0.], [0., -1.]];
+        let out = conv2d(&input, &kernel);
+        assert_eq!(out, array![[-4., -4.], [-4., -4.]]);
+    }
+}

--- a/rust/ml/src/embedding.rs
+++ b/rust/ml/src/embedding.rs
@@ -1,0 +1,24 @@
+use ndarray::{Array1, Array2};
+
+/// Simple embedding lookup.
+pub fn embedding(weight: &Array2<f32>, indices: &Array1<usize>) -> Array2<f32> {
+    let mut out = Array2::zeros((indices.len(), weight.shape()[1]));
+    for (i, &idx) in indices.iter().enumerate() {
+        out.row_mut(i).assign(&weight.row(idx));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_embedding_lookup() {
+        let weight = array![[1., 2.], [3., 4.], [5., 6.]];
+        let idx = array![2usize, 0usize];
+        let out = embedding(&weight, &idx);
+        assert_eq!(out, array![[5., 6.], [1., 2.]]);
+    }
+}

--- a/rust/ml/src/lib.rs
+++ b/rust/ml/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod backend;
+pub mod attention;
+pub mod convolution;
+pub mod linear;
+pub mod embedding;
+pub mod normalization;
+pub mod rope;

--- a/rust/ml/src/linear.rs
+++ b/rust/ml/src/linear.rs
@@ -1,0 +1,25 @@
+use ndarray::{Array1, Array2, Axis};
+
+/// Applies a linear transformation: `output = input * weight^T + bias`.
+pub fn linear(input: &Array2<f32>, weight: &Array2<f32>, bias: Option<&Array1<f32>>) -> Array2<f32> {
+    let mut output = input.dot(&weight.t());
+    if let Some(b) = bias {
+        output = output + &b.view().insert_axis(Axis(0));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_linear() {
+        let input = array![[1., 2.]]; // (1,2)
+        let weight = array![[1., 0.], [0., 1.]]; // (2,2)
+        let bias = array![1., 1.];
+        let out = linear(&input, &weight, Some(&bias));
+        assert_eq!(out, array![[2., 3.]]);
+    }
+}

--- a/rust/ml/src/normalization.rs
+++ b/rust/ml/src/normalization.rs
@@ -1,0 +1,62 @@
+use ndarray::{Array1, Array2, Axis};
+
+/// Layer normalization following the transformer formulation.
+pub fn layer_norm(
+    input: &Array2<f32>,
+    weight: Option<&Array1<f32>>,
+    bias: Option<&Array1<f32>>,
+    eps: f32,
+) -> Array2<f32> {
+    let mean = input.mean_axis(Axis(1)).unwrap();
+    let var = input.var_axis(Axis(1), 0.0);
+    let mut output = input.to_owned();
+    for (mut row, (&m, &v)) in output
+        .axis_iter_mut(Axis(0))
+        .zip(mean.iter().zip(var.iter()))
+    {
+        let denom = (v + eps).sqrt();
+        row.mapv_inplace(|x| (x - m) / denom);
+    }
+    if let Some(w) = weight {
+        output = output * &w.view().insert_axis(Axis(0));
+    }
+    if let Some(b) = bias {
+        output = output + &b.view().insert_axis(Axis(0));
+    }
+    output
+}
+
+/// Root mean square normalization.
+pub fn rms_norm(input: &Array2<f32>, weight: Option<&Array1<f32>>, eps: f32) -> Array2<f32> {
+    let mean_square = input.mapv(|x| x * x).mean_axis(Axis(1)).unwrap();
+    let mut output = input.to_owned();
+    for (mut row, &ms) in output.axis_iter_mut(Axis(0)).zip(mean_square.iter()) {
+        let denom = (ms + eps).sqrt();
+        row.mapv_inplace(|x| x / denom);
+    }
+    if let Some(w) = weight {
+        output = output * &w.view().insert_axis(Axis(0));
+    }
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_layer_norm_constant() {
+        let input = array![[1., 1.], [1., 1.]];
+        let out = layer_norm(&input, None, None, 1e-5);
+        assert_eq!(out, array![[0., 0.], [0., 0.]]);
+    }
+
+    #[test]
+    fn test_rms_norm_constant() {
+        let input = array![[3., 4.]]; // RMS = 5
+        let out = rms_norm(&input, None, 1e-6);
+        let mean_sq = out.mapv(|x| x.powi(2)).mean().unwrap();
+        assert!((mean_sq - 1.0).abs() < 1e-6);
+    }
+}

--- a/rust/ml/src/rope.rs
+++ b/rust/ml/src/rope.rs
@@ -1,0 +1,42 @@
+use ndarray::{Array1, Array2};
+
+/// Applies rotary positional embeddings (RoPE) to the given tensor.
+///
+/// `x` has shape `(seq_len, dim)` where `dim` is even. `positions` is a
+/// vector of length `seq_len` describing the token positions.
+pub fn apply_rope(x: &Array2<f32>, positions: &Array1<f32>) -> Array2<f32> {
+    let (seq_len, dim) = x.dim();
+    assert_eq!(positions.len(), seq_len);
+    assert!(dim % 2 == 0, "dimension must be even");
+    let half = dim / 2;
+    let mut out = x.clone();
+    for (t, &pos) in positions.iter().enumerate() {
+        for i in 0..half {
+            let freq = (2 * i) as f32 / dim as f32;
+            let theta = pos / 10000f32.powf(freq);
+            let cos = theta.cos();
+            let sin = theta.sin();
+            let x0 = x[(t, i)];
+            let x1 = x[(t, i + half)];
+            out[(t, i)] = x0 * cos - x1 * sin;
+            out[(t, i + half)] = x0 * sin + x1 * cos;
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ndarray::array;
+
+    #[test]
+    fn test_rope_preserves_norm() {
+        let x = array![[1., 0., 0., 1.]]; // seq_len=1, dim=4
+        let pos = array![1.0];
+        let out = apply_rope(&x, &pos);
+        let norm_before: f32 = x.iter().map(|v| v * v).sum();
+        let norm_after: f32 = out.iter().map(|v| v * v).sum();
+        assert!((norm_before - norm_after).abs() < 1e-6);
+    }
+}


### PR DESCRIPTION
## Summary
- add `ml` crate implementing neural network layers and backend selection
- provide attention, convolution, linear, embedding, normalization, and RoPE modules using `ndarray`
- include unit tests covering new modules

## Testing
- `cargo test` *(fails: cc1: fatal error: ffi/hello.c: No such file or directory)*
- `cd rust/ml && cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c5f469b9e8832fab2cee1e85e2cd4f