### PR TITLE
feat: add comprehensive Rust types and tests

### DIFF
--- a/rust/ollama_types/Cargo.lock
+++ b/rust/ollama_types/Cargo.lock
@@ -3,10 +3,23 @@
 version = 4
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
 name = "ollama_types"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -28,23 +41,51 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.219"
+name = "ryu"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
+name = "serde"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.144"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56177480b00303e689183f110b4e727bb4211d692c62d4fcd16d02be93077d40"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde_core",
 ]
 
 [[package]]

--- a/rust/ollama_types/Cargo.toml
+++ b/rust/ollama_types/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", features = ["derive"] }
+
+[dev-dependencies]
+serde_json = "1"

--- a/rust/ollama_types/src/model/name.rs
+++ b/rust/ollama_types/src/model/name.rs
@@ -179,7 +179,7 @@ impl fmt::Display for Name {
     }
 }
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug)]
 enum PartKind {
     Host,
     Namespace,
@@ -268,4 +268,33 @@ fn cut_promised(s: &str, sep: char) -> (String, String, bool) {
         },
         true,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_valid_part_cases() {
+        let cases = [
+            (PartKind::Host, "", false),
+            (PartKind::Host, "a", true),
+            (PartKind::Host, "a.", true),
+            (PartKind::Host, "a.b", true),
+            (PartKind::Host, "a:123", true),
+            (PartKind::Host, "a:123/aa/bb", false),
+            (PartKind::Namespace, "bb", true),
+            (PartKind::Namespace, "a.", false),
+            (PartKind::Model, "-h", false),
+            (
+                PartKind::Digest,
+                "sha256-1000000000000000000000000000000000000000000000000000000000000000",
+                true,
+            ),
+        ];
+
+        for (kind, s, want) in cases {
+            assert_eq!(is_valid_part(kind, s), want, "kind {:?} s {}", kind, s);
+        }
+    }
 }

--- a/rust/ollama_types/tests/capability.rs
+++ b/rust/ollama_types/tests/capability.rs
@@ -1,0 +1,11 @@
+use ollama_types::model::Capability;
+use serde_json;
+
+#[test]
+fn capability_serialization() {
+    let cap = Capability::Vision;
+    let json = serde_json::to_string(&cap).unwrap();
+    assert_eq!(json, "\"vision\"");
+    let de: Capability = serde_json::from_str(&json).unwrap();
+    assert_eq!(de, Capability::Vision);
+}

--- a/rust/ollama_types/tests/errtypes.rs
+++ b/rust/ollama_types/tests/errtypes.rs
@@ -1,0 +1,15 @@
+use ollama_types::errtypes::{UnknownOllamaKey, UNKNOWN_OLLAMA_KEY_ERR_MSG};
+use serde_json;
+
+#[test]
+fn unknown_key_display_and_serde() {
+    let err = UnknownOllamaKey { key: "abc".into() };
+    assert_eq!(
+        err.to_string(),
+        format!("unauthorized: {} \"abc\"", UNKNOWN_OLLAMA_KEY_ERR_MSG)
+    );
+    let json = serde_json::to_string(&err).unwrap();
+    assert_eq!(json, "{\"key\":\"abc\"}");
+    let de: UnknownOllamaKey = serde_json::from_str(&json).unwrap();
+    assert_eq!(de.key, "abc");
+}

--- a/rust/ollama_types/tests/name.rs
+++ b/rust/ollama_types/tests/name.rs
@@ -3,6 +3,8 @@ use ollama_types::model::{
     is_valid_namespace, parse_name, parse_name_bare, parse_name_from_filepath, Name,
 };
 
+const PART80: &str = "88888888888888888888888888888888888888888888888888888888888888888888888888888888";
+
 fn join(parts: &[&str]) -> PathBuf {
     let mut pb = PathBuf::new();
     for p in parts {
@@ -13,14 +15,15 @@ fn join(parts: &[&str]) -> PathBuf {
 
 #[test]
 fn parse_name_parts() {
-    struct Case<'a> {
-        input: &'a str,
+    let part350 = "3".repeat(350);
+    struct Case {
+        input: String,
         want: Name,
         filepath: PathBuf,
     }
     let cases = vec![
         Case {
-            input: "registry.ollama.ai/library/dolphin-mistral:7b-v2.6-dpo-laser-q6_K",
+            input: "registry.ollama.ai/library/dolphin-mistral:7b-v2.6-dpo-laser-q6_K".into(),
             want: Name {
                 host: "registry.ollama.ai".into(),
                 namespace: "library".into(),
@@ -35,7 +38,7 @@ fn parse_name_parts() {
             ]),
         },
         Case {
-            input: "scheme://host:port/namespace/model:tag",
+            input: "scheme://host:port/namespace/model:tag".into(),
             want: Name {
                 host: "host:port".into(),
                 namespace: "namespace".into(),
@@ -45,7 +48,7 @@ fn parse_name_parts() {
             filepath: join(&["host:port", "namespace", "model", "tag"]),
         },
         Case {
-            input: "host/namespace/model:tag",
+            input: "host/namespace/model:tag".into(),
             want: Name {
                 host: "host".into(),
                 namespace: "namespace".into(),
@@ -55,7 +58,7 @@ fn parse_name_parts() {
             filepath: join(&["host", "namespace", "model", "tag"]),
         },
         Case {
-            input: "host/namespace/model",
+            input: "host/namespace/model".into(),
             want: Name {
                 host: "host".into(),
                 namespace: "namespace".into(),
@@ -65,7 +68,7 @@ fn parse_name_parts() {
             filepath: join(&["host", "namespace", "model", "latest"]),
         },
         Case {
-            input: "namespace/model",
+            input: "namespace/model".into(),
             want: Name {
                 host: String::new(),
                 namespace: "namespace".into(),
@@ -75,7 +78,7 @@ fn parse_name_parts() {
             filepath: join(&["registry.ollama.ai", "namespace", "model", "latest"]),
         },
         Case {
-            input: "model",
+            input: "model".into(),
             want: Name {
                 host: String::new(),
                 namespace: String::new(),
@@ -84,12 +87,32 @@ fn parse_name_parts() {
             },
             filepath: join(&["registry.ollama.ai", "library", "model", "latest"]),
         },
+        Case {
+            input: format!("{PART80}/{PART80}/{PART80}:{PART80}"),
+            want: Name {
+                host: PART80.into(),
+                namespace: PART80.into(),
+                model: PART80.into(),
+                tag: PART80.into(),
+            },
+            filepath: join(&[PART80, PART80, PART80, PART80]),
+        },
+        Case {
+            input: format!("{part350}/{PART80}/{PART80}:{PART80}"),
+            want: Name {
+                host: part350.clone(),
+                namespace: PART80.into(),
+                model: PART80.into(),
+                tag: PART80.into(),
+            },
+            filepath: join(&[part350.as_str(), PART80, PART80, PART80]),
+        },
     ];
 
     for case in cases {
-        let got = parse_name_bare(case.input);
+        let got = parse_name_bare(&case.input);
         assert_eq!(got, case.want, "parse_name_bare {}", case.input);
-        let merged = parse_name(case.input);
+        let merged = parse_name(&case.input);
         assert_eq!(merged.filepath(), case.filepath, "filepath for {}", case.input);
     }
 }
@@ -146,4 +169,59 @@ fn is_valid_namespace_cases() {
     for (input, expected) in cases {
         assert_eq!(is_valid_namespace(input), expected, "{}", input);
     }
+}
+
+#[test]
+fn parse_name_default() {
+    let n = parse_name("xx");
+    assert_eq!(n.to_string(), "registry.ollama.ai/library/xx:latest");
+}
+
+#[test]
+fn name_is_valid() {
+    let part350 = "3".repeat(350);
+    let test_cases: Vec<(String, bool)> = vec![
+        ("".into(), false),
+        ("_why/_the/_lucky:_stiff".into(), true),
+        ("h/n/m:t".into(), true),
+        ("host/namespace/model:tag".into(), true),
+        ("host/namespace/model".into(), false),
+        ("namespace/model".into(), false),
+        ("model".into(), false),
+        (format!("{PART80}/{PART80}/{PART80}:{PART80}"), true),
+        (format!("{part350}/{PART80}/{PART80}:{PART80}"), true),
+        ("h/nn/mm:t".into(), true),
+        ("m".into(), false),
+        ("n/m:".into(), false),
+        ("h/n/m".into(), false),
+        ("@t".into(), false),
+        ("m@d".into(), false),
+        ("^".into(), false),
+        ("mm:".into(), false),
+        ("/nn/mm".into(), false),
+        ("//".into(), false),
+        ("//mm".into(), false),
+        ("hh//".into(), false),
+        ("//mm:@".into(), false),
+        ("00@".into(), false),
+        ("@".into(), false),
+        ("-hh/nn/mm:tt".into(), false),
+        ("hh/-nn/mm:tt".into(), false),
+        ("hh/nn/-mm:tt".into(), false),
+        ("hh/nn/mm:-tt".into(), false),
+        ("host:https/namespace/model:tag".into(), true),
+        ("host/name:space/model:tag".into(), false),
+    ];
+
+    let mut tested_string = false;
+    for (s, want) in test_cases {
+        let n = parse_name_bare(&s);
+        let got = n.is_valid();
+        assert_eq!(got, want, "is_valid {}", s);
+        if got {
+            assert_eq!(parse_name_bare(&s).to_string(), s);
+            tested_string = true;
+        }
+    }
+    assert!(tested_string, "no tests for Name::to_string");
 }

--- a/rust/ollama_types/tests/syncmap.rs
+++ b/rust/ollama_types/tests/syncmap.rs
@@ -1,0 +1,10 @@
+use ollama_types::syncmap::SyncMap;
+
+#[test]
+fn syncmap_basic_operations() {
+    let map: SyncMap<i32, String> = SyncMap::new();
+    map.store(1, "a".to_string());
+    assert_eq!(map.load(&1), Some("a".to_string()));
+    let items = map.items();
+    assert_eq!(items.get(&1).unwrap(), "a");
+}


### PR DESCRIPTION
## Summary
- add serde_json dev dependency for `ollama_types` crate
- implement internal validation tests for model names
- add serialization and basic operation tests for Capability, UnknownOllamaKey, and SyncMap

## Testing
- `cd rust/ollama_types && cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c6cf210fcc832f89627a2016e65991