### PR TITLE
feat(model): add byte pair encoding support

### DIFF
--- a/rust/model/Cargo.lock
+++ b/rust/model/Cargo.lock
@@ -86,6 +86,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bit_field"
 version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -360,6 +375,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,10 +622,13 @@ name = "model"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "fancy-regex",
  "fs",
  "image",
  "once_cell",
  "sentencepiece",
+ "serde",
+ "serde_json",
  "thiserror 1.0.69",
  "tokenizers",
 ]

--- a/rust/model/Cargo.toml
+++ b/rust/model/Cargo.toml
@@ -11,3 +11,6 @@ once_cell = "1.19"
 thiserror = "1.0"
 anyhow = "1.0"
 fs = { path = "../fs" }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+fancy-regex = "0.13"

--- a/rust/model/src/bytepair.rs
+++ b/rust/model/src/bytepair.rs
@@ -1,18 +1,118 @@
 use crate::{
     text_processor::TextProcessor,
-    vocabulary::{Special, Vocabulary},
+    vocabulary::{Special, Vocabulary, TOKEN_TYPE_CONTROL, TOKEN_TYPE_NORMAL},
 };
-use tokenizers::Tokenizer;
+use fancy_regex::Regex;
+use std::{
+    collections::HashMap,
+    fs::File,
+    io::{BufRead, BufReader},
+};
+use tokenizers::{
+    decoders::byte_level::ByteLevel as ByteLevelDecoder, models::bpe::BPE,
+    pre_tokenizers::byte_level::ByteLevel, AddedToken, Tokenizer,
+};
+
+const DEFAULT_PRE_REGEX: &str =
+    "(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\\r\\n\\p{L}\\p{N}]?\\p{L}+|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+";
 
 pub struct BytePairEncoding {
     tokenizer: Tokenizer,
     vocab: Vocabulary,
+    regex: Regex,
 }
 
 impl BytePairEncoding {
     pub fn from_file(json: &str, vocab: Vocabulary) -> anyhow::Result<Self> {
         let tokenizer = Tokenizer::from_file(json).map_err(|e| anyhow::anyhow!(e.to_string()))?;
-        Ok(Self { tokenizer, vocab })
+        let regex = Regex::new(DEFAULT_PRE_REGEX)?;
+        Ok(Self {
+            tokenizer,
+            vocab,
+            regex,
+        })
+    }
+
+    pub fn from_vocab_files(encoder: &str, merges: &str) -> anyhow::Result<Self> {
+        let file = File::open(encoder)?;
+        let mut map: HashMap<String, u32> = serde_json::from_reader(file)?;
+        let mut values = vec![String::new(); map.len()];
+        for (tok, id) in &map {
+            if (*id as usize) >= values.len() {
+                values.resize(*id as usize + 1, String::new());
+            }
+            values[*id as usize] = tok.clone();
+        }
+        let mut types = vec![TOKEN_TYPE_NORMAL; values.len()];
+        let mut next_id = values.len() as u32;
+        for special in ["<|begin_of_text|>", "<|end_of_text|>"] {
+            if !map.contains_key(special) {
+                map.insert(special.to_string(), next_id);
+                values.push(special.to_string());
+                types.push(TOKEN_TYPE_CONTROL);
+                next_id += 1;
+            } else if let Some(&id) = map.get(special) {
+                if (id as usize) >= types.len() {
+                    types.resize(id as usize + 1, TOKEN_TYPE_NORMAL);
+                }
+                types[id as usize] = TOKEN_TYPE_CONTROL;
+            }
+        }
+
+        let reader = BufReader::new(File::open(merges)?);
+        let mut merges_vec = Vec::new();
+        for line in reader.lines() {
+            let line = line?;
+            if line.starts_with('#') || line.trim().is_empty() {
+                continue;
+            }
+            if let Some((a, b)) = line.split_once(' ') {
+                merges_vec.push((a.to_string(), b.to_string()));
+            }
+        }
+
+        let bpe = BPE::builder()
+            .vocab_and_merges(map.clone(), merges_vec)
+            .build()
+            .map_err(|e| anyhow::anyhow!(e.to_string()))?;
+        let mut tokenizer = Tokenizer::new(bpe);
+        let pre = ByteLevel::default().add_prefix_space(false);
+        tokenizer.with_pre_tokenizer(pre);
+        let dec = ByteLevelDecoder::default().add_prefix_space(false);
+        tokenizer.with_decoder(dec);
+
+        tokenizer.add_special_tokens(&[
+            AddedToken::from("<|begin_of_text|>", true),
+            AddedToken::from("<|end_of_text|>", true),
+        ]);
+
+        let mut vocab = Vocabulary::new();
+        vocab.values = values;
+        vocab.types = types;
+        vocab.scores = vec![0.0; vocab.values.len()];
+        if let Some(&id) = map.get("<|begin_of_text|>") {
+            vocab.bos = vec![id as i32];
+        }
+        if let Some(&id) = map.get("<|end_of_text|>") {
+            vocab.eos = vec![id as i32];
+        }
+
+        let regex = Regex::new(DEFAULT_PRE_REGEX)?;
+        Ok(Self {
+            tokenizer,
+            vocab,
+            regex,
+        })
+    }
+
+    pub fn split(&self, s: &str) -> Vec<String> {
+        let mut out = Vec::new();
+        for m in self.regex.find_iter(s) {
+            if let Ok(mat) = m {
+                out.push(mat.as_str().to_string());
+            }
+        }
+        out
     }
 }
 

--- a/rust/model/tests/bytepair.rs
+++ b/rust/model/tests/bytepair.rs
@@ -1,0 +1,43 @@
+use model::{BytePairEncoding, TextProcessor};
+use std::path::PathBuf;
+
+fn load_llama_bpe() -> BytePairEncoding {
+    let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    path.push("../../model/testdata/llama3.2");
+    let encoder = path.join("encoder.json");
+    let merges = path.join("vocab.bpe");
+    BytePairEncoding::from_vocab_files(encoder.to_str().unwrap(), merges.to_str().unwrap()).unwrap()
+}
+
+#[test]
+fn test_simple_encode_decode() {
+    let tokenizer = load_llama_bpe();
+    let ids = tokenizer.encode("hello world", true).unwrap();
+    assert_eq!(ids, vec![15339, 1917]);
+    let decoded = tokenizer.decode(&ids).unwrap();
+    assert_eq!(decoded, "hello world");
+
+    let ids = tokenizer.encode("hello <|end_of_text|>", true).unwrap();
+    assert_eq!(ids, vec![15339, 220, 128001]);
+}
+
+#[test]
+fn test_split() {
+    let tokenizer = load_llama_bpe();
+    let splits = tokenizer.split("Hello, WORLD!! How's it going?");
+    assert_eq!(
+        splits,
+        vec!["Hello", ",", " WORLD", "!!", " How", "'s", " it", " going", "?",]
+    );
+}
+
+#[test]
+fn test_roundtrip_bytes() {
+    let tokenizer = load_llama_bpe();
+    for b in 0u8..=0xFF {
+        let input = (b as char).to_string();
+        let ids = tokenizer.encode(&input, false).unwrap();
+        let output = tokenizer.decode(&ids).unwrap();
+        assert_eq!(output, input);
+    }
+}


### PR DESCRIPTION
## Summary
- load BPE tokenizers from vocab and merge files
- support splitting text via regex similar to Go implementation
- cover byte pair encoding with new tests

## Testing
- `cd rust/model && cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c7341fb3e4832f967ee07d79e7a975