### PR TITLE
feat: add tensor reader abstractions

### DIFF
--- a/rust/convert/src/lib.rs
+++ b/rust/convert/src/lib.rs
@@ -4,8 +4,12 @@ use anyhow::Result;
 use fs::gguf::GgufFile;
 
 pub mod tokenizer;
+pub mod tensor;
+pub mod reader;
 
 pub use tokenizer::{parse_tokenizer, SpecialVocabulary, Tokenizer, Vocabulary};
+pub use tensor::{Tensor, TensorKind, Repacker, BaseTensor};
+pub use reader::{ModelReader, ModelWriter, FsReader, VecWriter};
 
 /// Enumeration of model formats supported by the converter.
 #[derive(Debug, Clone)]
@@ -30,25 +34,7 @@ pub enum ModelFormat {
     Unknown,
 }
 
-/// Trait representing a source of tensors.
-pub trait ModelReader {
-    fn read(&mut self, name: &str) -> Result<Tensor>;
-}
-
-/// Trait representing a sink for tensors.
-pub trait ModelWriter {
-    fn write(&mut self, tensor: &Tensor) -> Result<()>;
-}
-
-/// Basic tensor representation used by the converter.
-#[derive(Debug, Clone)]
-pub struct Tensor {
-    pub name: String,
-    pub shape: Vec<usize>,
-    pub dtype: String,
-}
-
-/// Convert a model in a given format.  This is currently a stub that simply
+/// Convert a model in a given format. This is currently a stub that simply
 /// validates input paths and returns success.
 pub fn convert_model<S: AsRef<Path>, D: AsRef<Path>>(
     src: S,

--- a/rust/convert/src/reader.rs
+++ b/rust/convert/src/reader.rs
@@ -1,0 +1,60 @@
+use std::{fs, path::PathBuf};
+
+use anyhow::{Result, bail};
+
+use crate::tensor::{Tensor, BaseTensor};
+
+/// Trait representing an abstract tensor reader.
+pub trait ModelReader {
+    fn read_tensors(&self) -> Result<Vec<Box<dyn Tensor>>>;
+}
+
+/// Trait representing an abstract tensor writer.
+pub trait ModelWriter {
+    fn write_tensor(&mut self, tensor: &dyn Tensor) -> Result<()>;
+}
+
+/// Simple filesystem based reader used for tests.
+#[derive(Debug, Clone)]
+pub struct FsReader {
+    root: PathBuf,
+}
+
+impl FsReader {
+    pub fn new<P: Into<PathBuf>>(root: P) -> Self { Self { root: root.into() } }
+}
+
+impl ModelReader for FsReader {
+    fn read_tensors(&self) -> Result<Vec<Box<dyn Tensor>>> {
+        let mut out: Vec<Box<dyn Tensor>> = Vec::new();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) == Some("tensor") {
+                // fake tensor file consisting of f32 values
+                let data = fs::read(&path)?;
+                let mut f32s = Vec::new();
+                for chunk in data.chunks(4) {
+                    f32s.push(f32::from_le_bytes(chunk.try_into().unwrap()));
+                }
+                let t = BaseTensor::new(path.file_stem().unwrap().to_string_lossy(), vec![f32s.len() as u64], f32s);
+                out.push(Box::new(t));
+            }
+        }
+        if out.is_empty() { bail!("unknown tensor format"); }
+        Ok(out)
+    }
+}
+
+/// In-memory writer collecting tensors.
+#[derive(Default)]
+pub struct VecWriter {
+    pub tensors: Vec<Box<dyn Tensor>>,
+}
+
+impl ModelWriter for VecWriter {
+    fn write_tensor(&mut self, tensor: &dyn Tensor) -> Result<()> {
+        self.tensors.push(tensor.clone_box());
+        Ok(())
+    }
+}

--- a/rust/convert/src/tensor.rs
+++ b/rust/convert/src/tensor.rs
@@ -1,0 +1,80 @@
+use std::io::{self, Write};
+
+/// Tensor data type used during conversion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TensorKind {
+    F32,
+    F16,
+    BF16,
+    MXFP4,
+}
+
+/// Function used to repack tensor data prior to writing.
+pub type Repacker = fn(&str, &[f32], &[u64]) -> io::Result<Vec<f32>>;
+
+/// Trait representing tensor operations used by the converter.
+pub trait Tensor: Send {
+    fn name(&self) -> &str;
+    fn shape(&self) -> &[u64];
+    fn kind(&self) -> TensorKind;
+    fn set_repacker(&mut self, repacker: Repacker);
+    fn write_to(&self, w: &mut dyn Write) -> io::Result<()>;
+    fn clone_box(&self) -> Box<dyn Tensor>;
+}
+
+impl Clone for Box<dyn Tensor> {
+    fn clone(&self) -> Self {
+        self.clone_box()
+    }
+}
+
+/// Basic in-memory tensor implementation used for tests and stubs.
+#[derive(Clone)]
+pub struct BaseTensor {
+    name: String,
+    shape: Vec<u64>,
+    data: Vec<f32>,
+    repacker: Option<Repacker>,
+}
+
+impl BaseTensor {
+    pub fn new<N: Into<String>>(name: N, shape: Vec<u64>, data: Vec<f32>) -> Self {
+        Self { name: name.into(), shape, data, repacker: None }
+    }
+}
+
+impl Tensor for BaseTensor {
+    fn name(&self) -> &str { &self.name }
+    fn shape(&self) -> &[u64] { &self.shape }
+    fn kind(&self) -> TensorKind {
+        if self.name.ends_with(".ffn_gate_inp.weight")
+            || self.name.ends_with(".bias")
+            || self.name == "token_types.weight"
+            || self.name == "v.positional_embedding_vlm"
+            || self.name == "v.tile_position_embd.weight"
+            || self.name == "v.pre_tile_position_embd.weight"
+            || self.name == "v.post_tile_position_embd.weight" {
+            return TensorKind::F32;
+        }
+        match self.shape.len() {
+            0 => panic!("invalid tensor shape"),
+            1 => TensorKind::F32,
+            _ => TensorKind::F16,
+        }
+    }
+    fn set_repacker(&mut self, repacker: Repacker) {
+        self.repacker = Some(repacker);
+    }
+    fn write_to(&self, w: &mut dyn Write) -> io::Result<()> {
+        let mut data = self.data.clone();
+        if let Some(rp) = self.repacker {
+            data = rp(&self.name, &data, &self.shape)?;
+        }
+        let mut bytes = Vec::with_capacity(data.len() * 4);
+        for f in data {
+            bytes.extend_from_slice(&f.to_le_bytes());
+        }
+        w.write_all(&bytes)
+    }
+    fn clone_box(&self) -> Box<dyn Tensor> { Box::new(self.clone()) }
+}

--- a/rust/convert/tests/tensor.rs
+++ b/rust/convert/tests/tensor.rs
@@ -1,0 +1,38 @@
+use std::{fs::File, io::Write};
+
+use convert::tensor::{BaseTensor, Tensor, TensorKind};
+use convert::reader::{FsReader, ModelReader};
+
+#[test]
+fn tensor_kind_from_shape() {
+    let t = BaseTensor::new("w", vec![2, 2], vec![0.0; 4]);
+    assert_eq!(t.kind(), TensorKind::F16);
+    let t = BaseTensor::new("b", vec![4], vec![0.0; 4]);
+    assert_eq!(t.kind(), TensorKind::F32);
+    let t = BaseTensor::new("x.bias", vec![2, 2], vec![0.0; 4]);
+    assert_eq!(t.kind(), TensorKind::F32);
+}
+
+#[test]
+fn repacker_invoked_on_write() {
+    let mut t = BaseTensor::new("w", vec![2], vec![1.0, 2.0]);
+    t.set_repacker(|_, data, _| Ok(data.iter().map(|v| v * 2.0).collect()));
+    let mut buf = Vec::new();
+    t.write_to(&mut buf).unwrap();
+    let mut out = [0u8; 8];
+    out.copy_from_slice(&buf);
+    let v1 = f32::from_le_bytes(out[0..4].try_into().unwrap());
+    let v2 = f32::from_le_bytes(out[4..8].try_into().unwrap());
+    assert_eq!((v1, v2), (2.0, 4.0));
+}
+
+#[test]
+fn fs_reader_loads_tensors() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut f = File::create(tmp.path().join("a.tensor")).unwrap();
+    f.write_all(&1.0f32.to_le_bytes()).unwrap();
+    let reader = FsReader::new(tmp.path());
+    let tensors = reader.read_tensors().unwrap();
+    assert_eq!(tensors.len(), 1);
+    assert_eq!(tensors[0].shape(), &[1]);
+}


### PR DESCRIPTION
## Summary
- introduce trait-based tensor and model reader implementations in convert crate
- port tokenizer and new tensor tests
- wire CLI and server to use Rust convert stub

## Testing
- `cargo test` (convert)
- `cargo test` (cli)
- `cargo test` (server)


------
https://chatgpt.com/codex/tasks/task_b_68c74760f1dc832fbbae0405a0900142