### PR TITLE
Integrate GGUF writer with converter and add config path tests

### DIFF
--- a/rust/convert/src/lib.rs
+++ b/rust/convert/src/lib.rs
@@ -1,7 +1,8 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use anyhow::Result;
-use fs::gguf::GgufFile;
+use fs::gguf::{write_gguf, GgufFile, Value};
 
 pub mod tokenizer;
 pub mod tensor;
@@ -41,11 +42,16 @@ pub fn convert_model<S: AsRef<Path>, D: AsRef<Path>>(
     dst: D,
     _format: ModelFormat,
 ) -> Result<()> {
-    let _ = dst.as_ref();
     if src.as_ref().is_file() {
         // Attempt to open the source as a GGUF file to exercise the reader. Any
         // error is ignored since conversion logic is not yet implemented.
         let _ = GgufFile::open(src.as_ref());
     }
+    let mut kv = HashMap::new();
+    kv.insert(
+        "general.architecture".to_string(),
+        Value::String("stub".into()),
+    );
+    write_gguf(dst.as_ref(), &kv, &[])?;
     Ok(())
 }

--- a/rust/convert/tests/convert.rs
+++ b/rust/convert/tests/convert.rs
@@ -1,10 +1,12 @@
 use std::path::Path;
 
 use convert::{convert_model, ModelFormat};
+use fs::gguf::GgufFile;
 
 #[test]
-fn convert_stub_runs() {
-    let src = Path::new(".");
-    let dst = Path::new("model.bin");
-    convert_model(src, dst, ModelFormat::LLaMA).unwrap();
+fn convert_writes_gguf() {
+    let dir = tempfile::tempdir().unwrap();
+    let dst = dir.path().join("out.gguf");
+    convert_model(Path::new("."), &dst, ModelFormat::LLaMA).unwrap();
+    GgufFile::open(&dst).unwrap();
 }

--- a/rust/fs/src/config.rs
+++ b/rust/fs/src/config.rs
@@ -27,4 +27,13 @@ mod tests {
         assert_eq!(config_dir(), dir);
         env::remove_var("OLLAMA_CONFIG");
     }
+
+    #[test]
+    fn home_default() {
+        env::remove_var("OLLAMA_CONFIG");
+        let dir = tempfile::tempdir().unwrap();
+        env::set_var("HOME", dir.path());
+        assert_eq!(config_dir(), dir.path().join(".ollama"));
+        env::remove_var("HOME");
+    }
 }

--- a/rust/model/Cargo.lock
+++ b/rust/model/Cargo.lock
@@ -351,6 +351,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "esaxx-rs"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +394,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "fdeflate"
@@ -431,7 +447,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.5+wasi-0.2.4",
 ]
 
 [[package]]
@@ -574,6 +602,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -629,6 +663,7 @@ dependencies = [
  "sentencepiece",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
  "tokenizers",
 ]
@@ -815,6 +850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -841,7 +882,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -903,6 +944,19 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags 2.9.4",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.60.2",
+]
 
 [[package]]
 name = "ryu"
@@ -1033,6 +1087,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84fa4d11fadde498443cca10fd3ac23c951f0dc59e080e9f4b93d4df4e4eea53"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1093,7 +1160,7 @@ dependencies = [
  "clap",
  "derive_builder",
  "esaxx-rs",
- "getrandom",
+ "getrandom 0.2.16",
  "indicatif",
  "itertools 0.12.1",
  "lazy_static",
@@ -1160,6 +1227,24 @@ name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.5+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4494f6290a82f5fe584817a676a34b9d6763e8d9d18204009fb31dceca98fd4"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.0+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fa2761397e5bd52002cd7e73110c71af2109aca4e521a9f40473fe685b0a24"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasm-bindgen"
@@ -1387,6 +1472,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c573471f125075647d03df72e026074b7203790d41351cd6edc96f46bcccd36"
 
 [[package]]
 name = "zerocopy"

--- a/rust/model/Cargo.toml
+++ b/rust/model/Cargo.toml
@@ -14,3 +14,6 @@ fs = { path = "../fs" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 fancy-regex = "0.13"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust/model/tests/model.rs
+++ b/rust/model/tests/model.rs
@@ -1,8 +1,9 @@
 use model::{
-    get_text_processor, parse_tags, register_model, Model, ModelError, RegisteredModel, Special,
-    TextProcessor, Vocabulary,
+    default_config_path, get_text_processor, parse_tags, register_model, Model, ModelError,
+    RegisteredModel, Special, TextProcessor, Vocabulary,
 };
 use once_cell::sync::Lazy;
+use std::env;
 
 struct DummyTP;
 impl Model for DummyTP {}
@@ -48,4 +49,12 @@ fn test_get_text_processor() {
         Err(ModelError::NotTextProcessor) => {}
         _ => panic!("unexpected error"),
     }
+}
+
+#[test]
+fn test_default_config_path_env() {
+    let dir = tempfile::tempdir().unwrap();
+    env::set_var("OLLAMA_CONFIG", dir.path());
+    assert_eq!(default_config_path(), dir.path());
+    env::remove_var("OLLAMA_CONFIG");
 }


### PR DESCRIPTION
## Summary
- add default HOME fallback test for configuration directory utility
- teach converter to emit a minimal GGUF file via safe writer
- validate model config path via environment-aware test

## Testing
- `cargo test` (fs)
- `cargo test` (convert)
- `cargo test` (model)


------
https://chatgpt.com/codex/tasks/task_b_68c7670dd530832fa5e812583dd9d201