### PR TITLE
feat(llm): handle case-insensitive env filtering

### DIFF
--- a/rust/llm/src/process.rs
+++ b/rust/llm/src/process.rs
@@ -3,22 +3,19 @@ use std::process::{Child, Command};
 
 /// Returns environment variables filtered to only those that should be passed to the runner.
 pub fn filtered_env() -> Vec<(String, String)> {
-    let allow_keys = [
-        "PATH",
-        "LD_LIBRARY_PATH",
-        "DYLD_LIBRARY_PATH",
-    ];
+    let allow_keys = ["PATH", "LD_LIBRARY_PATH", "DYLD_LIBRARY_PATH"];
     let mut envs = Vec::new();
     for (key, value) in env::vars() {
-        let allow = key.starts_with("OLLAMA_")
-            || key.starts_with("CUDA_")
-            || key.starts_with("ROCR_")
-            || key.starts_with("ROCM_")
-            || key.starts_with("HIP_")
-            || key.starts_with("GPU_")
-            || key.starts_with("HSA_")
-            || key.starts_with("GGML_")
-            || allow_keys.contains(&key.as_str());
+        let upper = key.to_ascii_uppercase();
+        let allow = upper.starts_with("OLLAMA_")
+            || upper.starts_with("CUDA_")
+            || upper.starts_with("ROCR_")
+            || upper.starts_with("ROCM_")
+            || upper.starts_with("HIP_")
+            || upper.starts_with("GPU_")
+            || upper.starts_with("HSA_")
+            || upper.starts_with("GGML_")
+            || allow_keys.iter().any(|k| k.eq(&upper));
         if allow {
             envs.push((key, value));
         }

--- a/rust/llm/tests/process.rs
+++ b/rust/llm/tests/process.rs
@@ -1,0 +1,40 @@
+use std::collections::HashMap;
+use std::env;
+
+use llm::filtered_env;
+
+#[test]
+fn test_filtered_env_case_insensitive() {
+    // Save existing vars to restore later
+    let orig_path = env::var("Path").ok();
+    let orig_ollama = env::var("OLLAMA_Test").ok();
+    let orig_other = env::var("UNRELATED_VAR").ok();
+
+    env::set_var("Path", "abc");
+    env::set_var("OLLAMA_Test", "123");
+    env::set_var("UNRELATED_VAR", "xxx");
+
+    let envs = filtered_env();
+    let map: HashMap<_, _> = envs.into_iter().collect();
+
+    assert_eq!(map.get("Path"), Some(&"abc".to_string()));
+    assert_eq!(map.get("OLLAMA_Test"), Some(&"123".to_string()));
+    assert!(map.get("UNRELATED_VAR").is_none());
+
+    // Restore
+    if let Some(v) = orig_path {
+        env::set_var("Path", v);
+    } else {
+        env::remove_var("Path");
+    }
+    if let Some(v) = orig_ollama {
+        env::set_var("OLLAMA_Test", v);
+    } else {
+        env::remove_var("OLLAMA_Test");
+    }
+    if let Some(v) = orig_other {
+        env::set_var("UNRELATED_VAR", v);
+    } else {
+        env::remove_var("UNRELATED_VAR");
+    }
+}


### PR DESCRIPTION
## Summary
- handle env vars case-insensitively when spawning llama runner
- test env filtering behavior

## Testing
- `cargo test --locked`


------
https://chatgpt.com/codex/tasks/task_b_68c7b6a56c50832f8b8b122cfbe303cd