### PR TITLE
feat(rust): port tool parser and template tag logic

### DIFF
--- a/rust/tools/src/lib.rs
+++ b/rust/tools/src/lib.rs
@@ -252,7 +252,8 @@ pub fn parse_tag(tmpl: &str) -> String {
             if expr.contains(".ToolCalls") {
                 let after = &tmpl[end+2..];
                 let (tag, _) = scan_block(after);
-                return tag.unwrap_or_else(|| "{".to_string());
+                let res = tag.map(|t| t.trim().to_string()).unwrap_or_else(|| "{".to_string());
+                return if res == "]" || res == "}" { "{".to_string() } else { res };
             }
             pos = end + 2;
         } else { break; }
@@ -308,7 +309,7 @@ fn extract_tag(text: &str) -> Option<String> {
     let trimmed = text.trim_start();
     let cut = trimmed.find('{').unwrap_or(trimmed.len());
     let tag = trimmed[..cut].trim();
-    if tag.is_empty() { None } else { Some(tag.to_string()) }
+    if tag.is_empty() || tag.contains('"') { None } else { Some(tag.to_string()) }
 }
 
 // Utility

--- a/rust/tools/tests/template.rs
+++ b/rust/tools/tests/template.rs
@@ -1,0 +1,53 @@
+use tools::parse_tag;
+
+#[test]
+fn parse_tag_tests() {
+    struct Case<'a> { name: &'a str, template: &'a str, want: &'a str }
+    let cases = vec![
+        Case { name: "empty", template: "", want: "{" },
+        Case { name: "no tag", template: r#"{{if .ToolCalls}}{{end}}"#, want: "{" },
+        Case { name: "no tag with range", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}{{ . }}{{end}}{{end}}"#, want: "{" },
+        Case { name: "tool call with json format", template: r#"{{if .ToolCalls}}```json
+{{end}}"#, want: "```json" },
+        Case { name: "square brackets", template: r#"{{if .ToolCalls}}[{{range .ToolCalls}}{{ . }}{{end}}]{{end}}"#, want: "[" },
+        Case { name: "square brackets with whitespace", template: r#"{{if .ToolCalls}}
+ [ {{range .ToolCalls}}{{ . }}{{end}}]{{end}}"#, want: "[" },
+        Case { name: "tailing ]", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}{{ . }}{{end}}]{{end}}"#, want: "{" },
+        Case { name: "whitespace only", template: r#"{{if .ToolCalls}} {{range .ToolCalls}}{{ . }}{{end}}{{end}}"#, want: "{" },
+        Case { name: "whitespace only in range", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}
+{{ . }}
+{{end}}{{end}}"#, want: "{" },
+        Case { name: "json objects", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}{{end}}{{end}}"#, want: "{" },
+        Case { name: "json objects with whitespace", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}
+{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}{{end}}{{end}}"#, want: "{" },
+        Case { name: "json objects with CRLF", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}
+
+{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}{{end}}{{end}}"#, want: "{" },
+        Case { name: "json objects with whitespace before and after range", template: r#"{{if .ToolCalls}}
+{{range .ToolCalls}}
+{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}
+
+{{end}}
+
+{{end}}"#, want: "{" },
+        Case { name: "before and after range", template: r#"{{if .ToolCalls}}<|tool▁calls▁begin|>{{range .ToolCalls}}<|tool▁call▁begin|>functionget_current_weather
+```json
+{"location": "Tokyo"}
+```<|tool▁call▁end|>
+{{end}}<|tool▁calls▁end|>{{end}}"#, want: "<|tool▁calls▁begin|>" },
+        Case { name: "after range", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}<tool_call>{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}</tool_call>{{end}}{{end}}"#, want: "<tool_call>" },
+        Case { name: "after range with leading whitespace before range", template: r#"{{if .ToolCalls}}
+{{range .ToolCalls}}<tool_call>{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}</tool_call>{{end}}{{end}}"#, want: "<tool_call>" },
+        Case { name: "tool call in range with {", template: r#"{{if .ToolCalls}}{{range .ToolCalls}}<tool_call>{"name": "{{ .Function.Name }}", "arguments": {{ .Function.Arguments }}}<tool_call>{{end}}{{end}}"#, want: "<tool_call>" },
+        Case { name: "tool call with multiple text nodes", template: r#"{{if .ToolCalls}}First text{{if .Something}}inner{{end}}Second text{{end}}"#, want: "First text" },
+        Case { name: "action tag", template: r#"{{if .ToolCalls}}Action: ```json{{end}}"#, want: "Action: ```json" },
+        Case { name: "incomplete functools bracket", template: r#"{{if .ToolCalls}}functools[{{end}}"#, want: "functools[" },
+        Case { name: "uppercase tool call with incomplete bracket", template: r#"{{if .ToolCalls}}[TOOL_CALL] [{{end}}"#, want: "[TOOL_CALL] [" },
+        Case { name: "uppercase tool call with adjacent bracket", template: r#"{{if .ToolCalls}}[TOOL_CALL][{{end}}"#, want: "[TOOL_CALL][" },
+    ];
+    for c in cases {
+        let got = parse_tag(c.template);
+        assert_eq!(got, c.want, "{}", c.name);
+    }
+}
+

--- a/rust/tools/tests/tools.rs
+++ b/rust/tools/tests/tools.rs
@@ -18,10 +18,13 @@ fn tools_list() -> Vec<Tool> {
 }
 
 #[test]
-fn parser_basic_cases() {
+fn parser_cases() {
     let tools = tools_list();
     let qwen = "{{if .ToolCalls}}<tool_call>{{range .ToolCalls}}{\"name\": \"{{.Function.Name}}\",\"arguments\": {{.Function.Arguments}}}{{end}}</tool_call>{{end}}";
+    let deepseek = "{{if .ToolCalls}}<|tool▁calls▁begin|>{{range .ToolCalls}}<|tool▁call▁begin|>function<|tool▁sep|>get_current_weather\n```json\n{\"location\": \"Tokyo\"}\n```<|tool▁call▁end|>{{end}}<|tool▁calls▁end|><|end▁of▁sentence|>{{end}}";
+    let json_tmpl = "{{if .ToolCalls}}{{range .ToolCalls}}{\"name\": \"{{.Function.Name}}\", \"arguments\": {{.Function.Arguments}}}{{end}}{{end}}";
     let list_tmpl = "{{if .ToolCalls}}[{{range .ToolCalls}}{\"name\": \"{{.Function.Name}}\", \"arguments\": {{.Function.Arguments}}}{{end}}]{{end}}";
+    let mistral = "{{if .ToolCalls}}[TOOL_CALLS] [{{range .ToolCalls}}{\"name\": \"{{.Function.Name}}\", \"arguments\": {{.Function.Arguments}}}{{end}}][/TOOL_CALLS]{{end}}";
 
     struct Case<'a> {
         name: &'a str,
@@ -31,19 +34,81 @@ fn parser_basic_cases() {
         calls: Vec<ToolCall>,
     }
 
-    let cases = vec![
-        Case { name: "no tool calls", inputs: vec!["Hello"], tmpl: qwen, content: "Hello", calls: vec![] },
+    let cases: Vec<Case> = vec![
+        Case { name: "no tool calls - just text", inputs: vec!["Hello, how can I help you today?"], tmpl: qwen, content: "Hello, how can I help you today?", calls: vec![] },
         Case { name: "empty input", inputs: vec![""], tmpl: qwen, content: "", calls: vec![] },
         Case { name: "tool call", inputs: vec!["<tool_call>{\"name\": \"get_conditions\", \"arguments\": {\"location\": \"San Francisco\"}}</tool_call>"], tmpl: qwen, content: "", calls: vec![ToolCall { function: ToolCallFunction { index: Some(0), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("San Francisco")); m } } }] },
         Case { name: "empty args", inputs: vec!["<tool_call>{\"name\": \"get_conditions\", \"arguments\": {}}</tool_call>"], tmpl: qwen, content: "", calls: vec![ToolCall { function: ToolCallFunction { index: Some(0), name: "get_conditions".to_string(), arguments: HashMap::new() } }] },
-        Case { name: "text before tool call", inputs: vec!["Let me check <tool_call>{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"New York\"}}</tool_call>"], tmpl: qwen, content: "Let me check ", calls: vec![ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("New York")); m } } }] },
-        Case { name: "two tool calls in list", inputs: vec!["[TOOL_CALLS] [{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"London\", \"format\": \"fahrenheit\"}}, {\"name\": \"get_conditions\", \"arguments\": {\"location\": \"Tokyo\"}}][/TOOL_CALLS]"], tmpl: "{{if .ToolCalls}}[TOOL_CALLS] [{{range .ToolCalls}}{\"name\": \"{{.Function.Name}}\", \"arguments\": {{.Function.Arguments}}}{{end}}][/TOOL_CALLS]{{end}}", content: "", calls: vec![
+        Case { name: "text before tool call", inputs: vec!["Let me check the weather. <tool_call>{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"New York\"}}</tool_call>"], tmpl: qwen, content: "Let me check the weather. ", calls: vec![ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("New York")); m } } }] },
+        Case { name: "qwen no args with text", inputs: vec!["Let me say hello to the user. I'll use the say_hello tool. "], tmpl: qwen, content: "Let me say hello to the user. I'll use the say_hello tool. ", calls: vec![] },
+        Case { name: "two tool calls in a list", inputs: vec!["[TOOL_CALLS] [{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"London\", \"format\": \"fahrenheit\"}}, {\"name\": \"get_conditions\", \"arguments\": {\"location\": \"Tokyo\"}}][/TOOL_CALLS]"], tmpl: mistral, content: "", calls: vec![
             ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("London")); m.insert("format".to_string(), json!("fahrenheit")); m } } },
             ToolCall { function: ToolCallFunction { index: Some(1), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
         ] },
-        Case { name: "list multiple", inputs: vec!["[", "{", "\"name\": \"get_temperature\", ", "\"arguments\": {", "\"city\": \"London\"", "}", "},", "{", "\"name\": \"get_conditions\", ", "\"arguments\": {", "\"location\": \"Tokyo\"", "}", "}", "]"], tmpl: list_tmpl, content: "", calls: vec![
+        Case { name: "qwen two tool calls", inputs: vec!["Okay, let's call both tools! <tool_call>{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"London\", \"format\": \"fahrenheit\"}}</tool_call><tool_call>{\"name\": \"get_conditions\", \"arguments\": {\"location\": \"Tokyo\"}}</tool_call>"], tmpl: qwen, content: "Okay, let's call both tools! ", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("London")); m.insert("format".to_string(), json!("fahrenheit")); m } } },
+            ToolCall { function: ToolCallFunction { index: Some(1), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "empty args followed by args", inputs: vec!["Let me say hello and check the weather. <tool_call>{\"name\": \"say_hello\", \"arguments\": {}}</tool_call><tool_call>{\"name\": \"get_temperature\", \"arguments\": {\"city\": \"London\", \"format\": \"fahrenheit\"}}</tool_call>"], tmpl: qwen, content: "Let me say hello and check the weather. ", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello".to_string(), arguments: HashMap::new() } },
+            ToolCall { function: ToolCallFunction { index: Some(1), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("London")); m.insert("format".to_string(), json!("fahrenheit")); m } } },
+        ] },
+        Case { name: "qwen empty followed by args", inputs: vec!["Let me check the weather. <tool_call>{\"name\": \"get_conditions\", \"arguments\": {}}</tool_call><tool_call>{\"name\": \"get_conditions\", \"arguments\": {\"location\": \"Tokyo\"}}"], tmpl: qwen, content: "Let me check the weather. ", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_conditions".to_string(), arguments: HashMap::new() } },
+            ToolCall { function: ToolCallFunction { index: Some(1), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "deepseek", inputs: vec!["<think>Wait, I need to call a tool</think><|tool▁calls▁begin|><|tool▁call▁begin|>function<|tool▁sep|>get_temperature\n```json\n{\"city\": \"Tokyo\"}\n```<|tool▁call▁end|><|tool▁calls▁end|><|end▁of▁sentence|>"], tmpl: deepseek, content: "<think>Wait, I need to call a tool</think>", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "deepseek incremental", inputs: vec!["<think>Wait", ", I need", " to call", " a tool</think><|too", "l▁calls▁begin|>", "<|tool▁call▁begin|>function<|tool▁sep|>get_temperature\n", "```json\n", "{\"city\": \"Tokyo\"}\n", "```", "<|tool▁call▁end|>", "<|tool▁calls▁end|>", "<|end▁of▁sentence|>"], tmpl: deepseek, content: "<think>Wait, I need to call a tool</think>", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "json", inputs: vec!["{", "\"name\": \"get_temperature\",", "\"arguments\": {", "\"city\": \"Tokyo\"", "}", "}"], tmpl: json_tmpl, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "json maybe a tool call", inputs: vec!["{", "\"name\": \"get_temperature\",", "\"arguments\": {"], tmpl: json_tmpl, content: "", calls: vec![] },
+        Case { name: "json not a tool call", inputs: vec!["{", "\"name\": \"search\", ", "\"arguments\": {", "\"query\": \"What is the capital of Canada?\"", "}", "}"], tmpl: json_tmpl, content: "{\"name\": \"search\", \"arguments\": {\"query\": \"What is the capital of Canada?\"}}", calls: vec![] },
+        Case { name: "json object followed by tool call", inputs: vec!["{\"name\": \"jeff\"}", "{\"name\": \"get_conditions\", \"arguments\": {\"location\": \"San Francisco\"}}"], tmpl: json_tmpl, content: "{\"name\": \"jeff\"}{\"name\": \"get_conditions\", \"arguments\": {\"location\": \"San Francisco\"}}", calls: vec![] },
+        Case { name: "json object followed by tool call split", inputs: vec!["{\"name\": \"jeff\"} {", "\"name\": \"get_conditions\", \"arguments\": {\"location\": \"San Francisco\"}}"], tmpl: json_tmpl, content: "{\"name\": \"jeff\"} {\"name\": \"get_conditions\", \"arguments\": {\"location\": \"San Francisco\"}}", calls: vec![] },
+        Case { name: "json code", inputs: vec!["for { fmt.Println(\"hello\") }"], tmpl: json_tmpl, content: "for { fmt.Println(\"hello\") }", calls: vec![] },
+        Case { name: "list multiple", inputs: vec!["[", "{", "\"name\": \"get_temperature\", ", "\"arguments\": {", "\"city\": \"London\"", "}", "},", "{", "\"name\": \"get_conditions\", ", "\"arguments\": {", "\"location\": \"Tokyo\"", "}", "}]"], tmpl: list_tmpl, content: "", calls: vec![
             ToolCall { function: ToolCallFunction { index: Some(0), name: "get_temperature".to_string(), arguments: { let mut m=HashMap::new(); m.insert("city".to_string(), json!("London")); m } } },
             ToolCall { function: ToolCallFunction { index: Some(1), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "list partial", inputs: vec!["[{", "\"name\": \"get_conditions\", ", "\"arguments\": {", "\"location\": \"Tokyo\"", "}", "}"], tmpl: list_tmpl, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "list invalid", inputs: vec!["[", "{", "\"name\": \"search\", ", "\"arguments\": {", "\"query\": \"What is the capital of Canada?\"", "}", "}"], tmpl: list_tmpl, content: "", calls: vec![] },
+        Case { name: "list trailing ]", inputs: vec!["[", "{", "\"name\": \"get_conditions\", ", "\"arguments\": {", "\"location\": \"Tokyo\"", "}", "}", "]", "]"], tmpl: list_tmpl, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_conditions".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("Tokyo")); m } } },
+        ] },
+        Case { name: "list not a tool call", inputs: vec!["[special", " del", "ivery]"], tmpl: list_tmpl, content: "[special delivery]", calls: vec![] },
+        Case { name: "tool name with collision", inputs: vec!["<tool_call>", "{", "\"name\": \"say_hello", "_world\",", "\"arguments\": {}}", "}"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello_world".to_string(), arguments: HashMap::new() } },
+        ] },
+        Case { name: "tool name with collision multiple", inputs: vec!["<tool_call>", "{", "\"name\": \"say_hello", "_world\",", "\"arguments\": {}}", "</tool_call>", "<tool_call>", "{", "\"name\": \"say_hello\",", "\"arguments\": {}}", "</tool_call>"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello_world".to_string(), arguments: HashMap::new() } },
+            ToolCall { function: ToolCallFunction { index: Some(1), name: "say_hello".to_string(), arguments: HashMap::new() } },
+        ] },
+        Case { name: "tool name with collision non streaming", inputs: vec!["<tool_call>{\"name\": \"say_hello"], tmpl: qwen, content: "", calls: vec![] },
+        Case { name: "tool name with collision non streaming multiple", inputs: vec!["<tool_call>{\"name\": \"say_hello\", \"arguments\": {}}</tool_call><tool_call>{\"name\": \"say_hello_world\", \"arguments\": {}}"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello".to_string(), arguments: HashMap::new() } },
+            ToolCall { function: ToolCallFunction { index: Some(1), name: "say_hello_world".to_string(), arguments: HashMap::new() } },
+        ] },
+        Case { name: "tool name with collision non streaming shorter", inputs: vec!["<tool_call>{\"name\": \"say_hello\", \"arguments\": {}}</tool_call>"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello".to_string(), arguments: HashMap::new() } },
+        ] },
+        Case { name: "tool name with collision non streaming longer", inputs: vec!["<tool_call>{\"name\": \"say_hello_world\", \"arguments\": {}}</tool_call>"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "say_hello_world".to_string(), arguments: HashMap::new() } },
+        ] },
+        Case { name: "tool name with substring of another json", inputs: vec!["{", "\"name\": \"get_address\",", "\"arguments\": {", "\"location\": \"London\"", "}", "}"], tmpl: json_tmpl, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_address".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("London")); m } } },
+        ] },
+        Case { name: "tool name with substring of another", inputs: vec!["<tool_call>{\"name\": \"get_address\", \"arguments\": {\"location\": \"London\"}}</tool_call>"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "get_address".to_string(), arguments: { let mut m=HashMap::new(); m.insert("location".to_string(), json!("London")); m } } },
+        ] },
+        Case { name: "args before name", inputs: vec!["<tool_call>{\"arguments\": {\"a\": \"5\", \"b\": \"10\"}, \"name\": \"add\"}</tool_call>"], tmpl: qwen, content: "", calls: vec![
+            ToolCall { function: ToolCallFunction { index: Some(0), name: "add".to_string(), arguments: { let mut m=HashMap::new(); m.insert("a".to_string(), json!("5")); m.insert("b".to_string(), json!("10")); m } } },
         ] },
     ];
 
@@ -71,6 +136,7 @@ fn parser_done_tests() {
         Case { name: "json empty", tag: "{", buffer: "{}", want: true },
         Case { name: "list open", tag: "[", buffer: "[{\"name\": \"get_weather\"", want: false },
         Case { name: "list closed", tag: "[", buffer: "[{\"name\": \"get_weather\"}]", want: true },
+        Case { name: "list empty", tag: "[", buffer: "[]", want: true },
     ];
     let tools = tools_list();
     for c in cases {
@@ -79,3 +145,4 @@ fn parser_done_tests() {
         assert_eq!(p.done(), c.want, "{}", c.name);
     }
 }
+


### PR DESCRIPTION
## Summary
- implement tool parser and tag extraction in Rust
- cover tool and template parsing with extensive unit tests

## Testing
- `cd rust/tools && cargo test`

------
https://chatgpt.com/codex/tasks/task_b_68c8324cdf88832f9291d7ec3aa02819