### PR TITLE
Add Rust thinking template parser and tests

### DIFF
--- a/rust/parser/Cargo.lock
+++ b/rust/parser/Cargo.lock
@@ -3,15 +3,6 @@
 version = 4
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -107,7 +98,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "glob",
- "regex",
  "serde",
  "serde_json",
  "sha2",
@@ -133,35 +123,6 @@ checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
-
-[[package]]
-name = "regex"
-version = "1.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23d7fd106d8c02486a8d64e778353d1cffe08ce79ac2e82f540c86d0facf6912"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b9458fa0bfeeac22b5ca447c63aaf45f28439a709ccd244698632f9aa6394d6"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "ryu"

--- a/rust/parser/Cargo.toml
+++ b/rust/parser/Cargo.toml
@@ -10,6 +10,5 @@ walkdir = "2"
 glob = "0.3"
 thiserror = "1"
 users = "0.11"
-regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/parser/src/thinking/mod.rs
+++ b/rust/parser/src/thinking/mod.rs
@@ -1,5 +1,5 @@
 pub mod parser;
 pub mod template;
 
-pub use parser::Parser;
+pub use parser::{Parser, State};
 pub use template::infer_tags;

--- a/rust/parser/src/thinking/parser.rs
+++ b/rust/parser/src/thinking/parser.rs
@@ -1,7 +1,7 @@
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum State {
+pub enum State {
     LookingForOpening,
     ThinkingStartedEatingWhitespace,
     Thinking,
@@ -47,22 +47,27 @@ impl Parser {
         }
         (thinking, remaining)
     }
+
+    pub fn state(&self) -> State {
+        self.state
+    }
 }
 
 fn eat(p: &mut Parser) -> (String, String, bool) {
     match p.state {
         State::LookingForOpening => {
-            let trimmed = p.acc.trim_start();
-            if trimmed.starts_with(&p.opening_tag) && !p.opening_tag.is_empty() {
+            let trimmed = p.acc.trim_start().to_string();
+            if trimmed.starts_with(&p.opening_tag) {
                 let after = trimmed[p.opening_tag.len()..].trim_start().to_string();
-                p.acc = after;
-                if p.acc.is_empty() {
+                p.acc.clear();
+                if after.is_empty() {
                     p.state = State::ThinkingStartedEatingWhitespace;
                 } else {
                     p.state = State::Thinking;
+                    p.acc.push_str(&after);
                 }
                 (String::new(), String::new(), true)
-            } else if !p.opening_tag.is_empty() && p.opening_tag.starts_with(trimmed) {
+            } else if !p.opening_tag.is_empty() && p.opening_tag.starts_with(trimmed.as_str()) {
                 (String::new(), String::new(), false)
             } else if trimmed.is_empty() {
                 (String::new(), String::new(), false)
@@ -74,11 +79,12 @@ fn eat(p: &mut Parser) -> (String, String, bool) {
         }
         State::ThinkingStartedEatingWhitespace => {
             let trimmed = p.acc.trim_start().to_string();
-            p.acc = trimmed.clone();
+            p.acc.clear();
             if trimmed.is_empty() {
                 (String::new(), String::new(), false)
             } else {
                 p.state = State::Thinking;
+                p.acc.push_str(&trimmed);
                 (String::new(), String::new(), true)
             }
         }
@@ -87,7 +93,7 @@ fn eat(p: &mut Parser) -> (String, String, bool) {
                 let thinking = p.acc[..idx].to_string();
                 let mut rem = p.acc[idx + p.closing_tag.len()..].to_string();
                 rem = rem.trim_start().to_string();
-                p.acc = rem.clone();
+                p.acc.clear();
                 if rem.is_empty() {
                     p.state = State::ThinkingDoneEatingWhitespace;
                 } else {
@@ -97,7 +103,8 @@ fn eat(p: &mut Parser) -> (String, String, bool) {
             } else if let Some(overlap) = overlap(&p.acc, &p.closing_tag) {
                 let thinking = p.acc[..p.acc.len() - overlap].to_string();
                 let rem = p.acc[p.acc.len() - overlap..].to_string();
-                p.acc = rem;
+                p.acc.clear();
+                p.acc.push_str(&rem);
                 (thinking, String::new(), false)
             } else {
                 let acc = std::mem::take(&mut p.acc);
@@ -106,7 +113,7 @@ fn eat(p: &mut Parser) -> (String, String, bool) {
         }
         State::ThinkingDoneEatingWhitespace => {
             let trimmed = p.acc.trim_start().to_string();
-            p.acc = trimmed.clone();
+            p.acc.clear();
             if trimmed.is_empty() {
                 (String::new(), String::new(), false)
             } else {
@@ -122,6 +129,9 @@ fn eat(p: &mut Parser) -> (String, String, bool) {
 }
 
 fn overlap(s: &str, delim: &str) -> Option<usize> {
+    if delim.is_empty() {
+        return None;
+    }
     let max = delim.len().min(s.len());
     for i in (1..=max).rev() {
         if s.ends_with(&delim[..i]) {
@@ -137,7 +147,11 @@ mod tests {
 
     #[test]
     fn basic_extract() {
-        let mut p = Parser { opening_tag: "<think>".into(), closing_tag: "</think>".into(), ..Default::default() };
+        let mut p = Parser {
+            opening_tag: "<think>".into(),
+            closing_tag: "</think>".into(),
+            ..Default::default()
+        };
         let (t, c) = p.add_content("<think>abc</think>def");
         assert_eq!(t, "abc");
         assert_eq!(c, "def");

--- a/rust/parser/src/thinking/template.rs
+++ b/rust/parser/src/thinking/template.rs
@@ -1,51 +1,476 @@
-use regex::Regex;
-
-/// Infer opening and closing tags that surround thinking traces.
+/// Infer opening and closing tags that surround thinking traces by walking a
+/// simplified parse tree of the template.
 pub fn infer_tags(tmpl: &str) -> (String, String) {
-    let re = Regex::new(r"(?s)\{\{-?\s*(.*?)\s*-?\}\}").unwrap();
-    let mut stack: Vec<String> = Vec::new();
-    let mut last_end = 0;
-    let mut open_tag = String::new();
-    let mut close_tag = String::new();
-    for mat in re.find_iter(tmpl) {
-        let token = &tmpl[mat.start()..mat.end()];
-        let inner = token.trim_start_matches("{{").trim_end_matches("}}");
-        let inner = inner.trim_matches('-').trim();
-        let before_text = &tmpl[last_end..mat.start()];
-        if inner.starts_with("range") {
-            if inner.contains(".Messages") {
-                stack.push("range_messages".into());
-            } else {
-                stack.push("range".into());
+    let ast = parse_template(tmpl);
+    let mut ancestors = Vec::new();
+    let mut result: Option<(String, String)> = None;
+    traverse_list(&ast, &mut ancestors, &mut result);
+    result.unwrap_or_default()
+}
+
+#[derive(Debug, Default)]
+struct ListNode {
+    nodes: Vec<Node>,
+}
+
+#[derive(Debug)]
+struct BranchNode {
+    pipe: String,
+    list: ListNode,
+    else_list: Option<ListNode>,
+}
+
+#[derive(Debug)]
+struct ActionNode {
+    raw: String,
+}
+
+#[derive(Debug)]
+enum Node {
+    Text(String),
+    Action(ActionNode),
+    Range(BranchNode),
+    If(BranchNode),
+    With(BranchNode),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum BranchKind {
+    Range,
+    If,
+    With,
+}
+
+#[derive(Debug)]
+enum Token {
+    Text(String),
+    Action(ActionToken),
+}
+
+#[derive(Debug)]
+struct ActionToken {
+    raw: String,
+    kind: ActionKind,
+}
+
+#[derive(Debug, Clone)]
+enum ActionKind {
+    RangeStart { pipe: String },
+    IfStart { pipe: String },
+    WithStart { pipe: String },
+    Else,
+    End,
+    Comment,
+    Other,
+}
+
+#[derive(Debug)]
+enum Context {
+    List {
+        nodes: Vec<Node>,
+    },
+    Branch {
+        kind: BranchKind,
+        pipe: String,
+        main: Vec<Node>,
+        else_nodes: Vec<Node>,
+        in_else: bool,
+    },
+}
+
+fn parse_template(input: &str) -> ListNode {
+    let tokens = tokenize(input);
+    let mut stack = vec![Context::List { nodes: Vec::new() }];
+    for token in tokens {
+        match token {
+            Token::Text(text) => {
+                current_nodes_mut(&mut stack).push(Node::Text(text));
             }
-        } else if inner.starts_with("end") {
-            stack.pop();
-        } else if inner.starts_with("if") || inner.starts_with("with") {
-            stack.push(inner.to_string());
-        } else if inner.contains(".Thinking") {
-            let mut most_recent_range = None;
-            for item in stack.iter().rev() {
-                if item.starts_with("range") {
-                    most_recent_range = Some(item.clone());
-                    break;
+            Token::Action(action) => match action.kind {
+                ActionKind::Comment => {}
+                ActionKind::Else => {
+                    if let Some(Context::Branch { in_else, .. }) = stack.last_mut() {
+                        *in_else = true;
+                    }
+                }
+                ActionKind::End => {
+                    if stack.len() <= 1 {
+                        continue;
+                    }
+                    let ctx = stack.pop().unwrap();
+                    if let Context::Branch {
+                        kind,
+                        pipe,
+                        main,
+                        else_nodes,
+                        ..
+                    } = ctx
+                    {
+                        let node = node_from_branch(kind, pipe, main, else_nodes);
+                        current_nodes_mut(&mut stack).push(node);
+                    }
+                }
+                ActionKind::RangeStart { pipe } => stack.push(Context::Branch {
+                    kind: BranchKind::Range,
+                    pipe,
+                    main: Vec::new(),
+                    else_nodes: Vec::new(),
+                    in_else: false,
+                }),
+                ActionKind::IfStart { pipe } => stack.push(Context::Branch {
+                    kind: BranchKind::If,
+                    pipe,
+                    main: Vec::new(),
+                    else_nodes: Vec::new(),
+                    in_else: false,
+                }),
+                ActionKind::WithStart { pipe } => stack.push(Context::Branch {
+                    kind: BranchKind::With,
+                    pipe,
+                    main: Vec::new(),
+                    else_nodes: Vec::new(),
+                    in_else: false,
+                }),
+                ActionKind::Other => {
+                    current_nodes_mut(&mut stack)
+                        .push(Node::Action(ActionNode { raw: action.raw }));
+                }
+            },
+        }
+    }
+
+    while stack.len() > 1 {
+        let ctx = stack.pop().unwrap();
+        if let Context::Branch {
+            kind,
+            pipe,
+            main,
+            else_nodes,
+            ..
+        } = ctx
+        {
+            let node = node_from_branch(kind, pipe, main, else_nodes);
+            current_nodes_mut(&mut stack).push(node);
+        }
+    }
+
+    match stack.pop().unwrap() {
+        Context::List { nodes } => ListNode { nodes },
+        Context::Branch { .. } => unreachable!(),
+    }
+}
+
+fn node_from_branch(
+    kind: BranchKind,
+    pipe: String,
+    main: Vec<Node>,
+    else_nodes: Vec<Node>,
+) -> Node {
+    let branch = BranchNode {
+        pipe,
+        list: ListNode { nodes: main },
+        else_list: if else_nodes.is_empty() {
+            None
+        } else {
+            Some(ListNode { nodes: else_nodes })
+        },
+    };
+
+    match kind {
+        BranchKind::Range => Node::Range(branch),
+        BranchKind::If => Node::If(branch),
+        BranchKind::With => Node::With(branch),
+    }
+}
+
+fn current_nodes_mut(stack: &mut Vec<Context>) -> &mut Vec<Node> {
+    match stack.last_mut().expect("empty context stack") {
+        Context::List { nodes } => nodes,
+        Context::Branch {
+            in_else,
+            main,
+            else_nodes,
+            ..
+        } => {
+            if *in_else {
+                else_nodes
+            } else {
+                main
+            }
+        }
+    }
+}
+
+fn tokenize(input: &str) -> Vec<Token> {
+    let mut tokens = Vec::new();
+    let mut idx = 0;
+    while idx < input.len() {
+        if let Some(open_rel) = input[idx..].find("{{") {
+            let start = idx + open_rel;
+            if start > idx {
+                tokens.push(Token::Text(input[idx..start].to_string()));
+            }
+
+            let after_open = start + 2;
+            if let Some(close_rel) = input[after_open..].find("}}") {
+                let end = after_open + close_rel;
+                let mut inner = &input[after_open..end];
+                if inner.starts_with('-') {
+                    inner = &inner[1..];
+                }
+                if inner.ends_with('-') {
+                    inner = &inner[..inner.len() - 1];
+                }
+                let trimmed = inner.trim();
+                let action_tokens = action_tokens(trimmed);
+                for act in action_tokens {
+                    tokens.push(Token::Action(act));
+                }
+                idx = end + 2;
+            } else {
+                tokens.push(Token::Text(input[start..].to_string()));
+                break;
+            }
+        } else {
+            tokens.push(Token::Text(input[idx..].to_string()));
+            break;
+        }
+    }
+    tokens
+}
+
+fn action_tokens(trimmed: &str) -> Vec<ActionToken> {
+    let mut actions = Vec::new();
+    if trimmed.is_empty() {
+        return actions;
+    }
+    if trimmed.starts_with("/*") {
+        actions.push(ActionToken {
+            raw: String::new(),
+            kind: ActionKind::Comment,
+        });
+        return actions;
+    }
+    if trimmed.starts_with("end") {
+        actions.push(ActionToken {
+            raw: trimmed.to_string(),
+            kind: ActionKind::End,
+        });
+        return actions;
+    }
+    if trimmed.starts_with("else if") {
+        actions.push(ActionToken {
+            raw: "else".to_string(),
+            kind: ActionKind::Else,
+        });
+        let rest = trimmed["else if".len()..].trim_start();
+        if !rest.is_empty() {
+            actions.push(ActionToken {
+                raw: format!("if {}", rest),
+                kind: ActionKind::Other,
+            });
+        }
+        return actions;
+    }
+    if trimmed.starts_with("else") {
+        actions.push(ActionToken {
+            raw: trimmed.to_string(),
+            kind: ActionKind::Else,
+        });
+        return actions;
+    }
+    if trimmed.starts_with("range") {
+        let pipe = trimmed["range".len()..].trim_start().to_string();
+        actions.push(ActionToken {
+            raw: trimmed.to_string(),
+            kind: ActionKind::RangeStart { pipe },
+        });
+        return actions;
+    }
+    if trimmed.starts_with("if") {
+        let pipe = trimmed["if".len()..].trim_start().to_string();
+        actions.push(ActionToken {
+            raw: trimmed.to_string(),
+            kind: ActionKind::IfStart { pipe },
+        });
+        return actions;
+    }
+    if trimmed.starts_with("with") {
+        let pipe = trimmed["with".len()..].trim_start().to_string();
+        actions.push(ActionToken {
+            raw: trimmed.to_string(),
+            kind: ActionKind::WithStart { pipe },
+        });
+        return actions;
+    }
+
+    actions.push(ActionToken {
+        raw: trimmed.to_string(),
+        kind: ActionKind::Other,
+    });
+    actions
+}
+
+#[derive(Debug)]
+enum Ancestor<'a> {
+    List(&'a ListNode),
+    Range(&'a BranchNode),
+}
+
+fn traverse_list<'a>(
+    list: &'a ListNode,
+    ancestors: &mut Vec<Ancestor<'a>>,
+    result: &mut Option<(String, String)>,
+) {
+    if result.is_some() {
+        return;
+    }
+    ancestors.push(Ancestor::List(list));
+    for node in &list.nodes {
+        if result.is_some() {
+            break;
+        }
+        match node {
+            Node::Text(_) => {}
+            Node::Action(action) => inspect_fields(&action.raw, ancestors, result),
+            Node::Range(branch) => {
+                ancestors.push(Ancestor::Range(branch));
+                inspect_fields(&branch.pipe, ancestors, result);
+                traverse_list(&branch.list, ancestors, result);
+                if result.is_none() {
+                    if let Some(else_list) = &branch.else_list {
+                        traverse_list(else_list, ancestors, result);
+                    }
+                }
+                ancestors.pop();
+            }
+            Node::If(branch) => {
+                inspect_fields(&branch.pipe, ancestors, result);
+                traverse_list(&branch.list, ancestors, result);
+                if result.is_none() {
+                    if let Some(else_list) = &branch.else_list {
+                        traverse_list(else_list, ancestors, result);
+                    }
                 }
             }
-            if let Some(r) = most_recent_range {
-                if r == "range_messages" {
-                    open_tag = before_text.trim().to_string();
-                    if let Some(next) = re.find_at(tmpl, mat.end()) {
-                        let after = &tmpl[mat.end()..next.start()];
-                        close_tag = after.trim().to_string();
-                    } else {
-                        let after = &tmpl[mat.end()..];
-                        close_tag = after.trim().to_string();
+            Node::With(branch) => {
+                inspect_fields(&branch.pipe, ancestors, result);
+                traverse_list(&branch.list, ancestors, result);
+                if result.is_none() {
+                    if let Some(else_list) = &branch.else_list {
+                        traverse_list(else_list, ancestors, result);
                     }
-                    break;
                 }
             }
         }
-        last_end = mat.end();
     }
-    (open_tag, close_tag)
+    ancestors.pop();
 }
 
+fn inspect_fields<'a>(
+    source: &str,
+    ancestors: &mut Vec<Ancestor<'a>>,
+    result: &mut Option<(String, String)>,
+) {
+    if result.is_some() {
+        return;
+    }
+    let allow_field = source.trim_start().starts_with('.');
+    for field in extract_fields(source) {
+        if let Some(name) = field.first() {
+            if name == "Thinking" && allow_field {
+                if let Some(tags) = infer_from_ancestors(ancestors) {
+                    *result = Some(tags);
+                    return;
+                }
+            }
+        }
+    }
+}
+
+fn infer_from_ancestors<'a>(ancestors: &[Ancestor<'a>]) -> Option<(String, String)> {
+    let mut nearest_range = None;
+    for anc in ancestors.iter().rev() {
+        if let Ancestor::Range(range) = anc {
+            nearest_range = Some(*range);
+            break;
+        }
+    }
+
+    let range = nearest_range?;
+    if !range_uses_field(&range, "Messages") {
+        return None;
+    }
+
+    for anc in ancestors.iter().rev() {
+        if let Ancestor::List(list) = anc {
+            let opening = list.nodes.first().and_then(|n| match n {
+                Node::Text(text) => Some(text.trim().to_string()),
+                _ => None,
+            });
+            let closing = list.nodes.last().and_then(|n| match n {
+                Node::Text(text) => Some(text.trim().to_string()),
+                _ => None,
+            });
+            if opening.is_some() || closing.is_some() {
+                return Some((opening.unwrap_or_default(), closing.unwrap_or_default()));
+            }
+        }
+    }
+
+    None
+}
+
+fn range_uses_field(range: &BranchNode, field: &str) -> bool {
+    extract_fields(&range.pipe)
+        .iter()
+        .any(|idents| idents.first().map(|n| n == field).unwrap_or(false))
+}
+
+fn extract_fields(source: &str) -> Vec<Vec<String>> {
+    let mut fields = Vec::new();
+    let bytes = source.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$' && i + 1 < bytes.len() && bytes[i + 1] == b'.' {
+            i += 1;
+        }
+        if bytes[i] == b'.' {
+            i += 1;
+            if i >= bytes.len() {
+                break;
+            }
+            if !(bytes[i] == b'_' || bytes[i].is_ascii_alphabetic()) {
+                continue;
+            }
+            let mut idents = Vec::new();
+            loop {
+                let start = i;
+                while i < bytes.len() && (bytes[i] == b'_' || bytes[i].is_ascii_alphanumeric()) {
+                    i += 1;
+                }
+                if start == i {
+                    break;
+                }
+                idents.push(source[start..i].to_string());
+                if i < bytes.len() && bytes[i] == b'.' {
+                    i += 1;
+                    if i >= bytes.len() {
+                        break;
+                    }
+                    if !(bytes[i] == b'_' || bytes[i].is_ascii_alphabetic()) {
+                        break;
+                    }
+                    continue;
+                }
+                break;
+            }
+            if !idents.is_empty() {
+                fields.push(idents);
+            }
+            continue;
+        }
+        i += 1;
+    }
+    fields
+}

--- a/rust/parser/tests/thinking_parser.rs
+++ b/rust/parser/tests/thinking_parser.rs
@@ -1,71 +1,275 @@
-use parser::thinking::Parser;
+use parser::thinking::{Parser, State};
 
 #[test]
 fn extract_thinking() {
     let tests = vec![
         ("<think> internal </think> world", "internal ", "world"),
-        ("<think>a</think><think>b</think>c", "a", "<think>b</think>c"),
+        (
+            "<think>a</think><think>b</think>c",
+            "a",
+            "<think>b</think>c",
+        ),
         ("no think", "", "no think"),
     ];
+
     for (input, want_think, want_content) in tests {
-        let mut p = Parser::default();
-        p.opening_tag = "<think>".into();
-        p.closing_tag = "</think>".into();
-        let (t, c) = p.add_content(input);
-        assert_eq!(t, want_think);
-        assert_eq!(c, want_content);
+        let mut parser = Parser::default();
+        parser.opening_tag = "<think>".into();
+        parser.closing_tag = "</think>".into();
+        let (thinking, content) = parser.add_content(input);
+        assert_eq!(thinking, want_think);
+        assert_eq!(content, want_content);
     }
 }
 
 #[test]
-fn thinking_streaming_basic() {
-    let mut p = Parser::default();
-    p.opening_tag = "<think>".into();
-    p.closing_tag = "</think>".into();
-    let (t, c) = p.add_content("<think>abc</think>\n\nhello");
-    assert_eq!(t, "abc");
-    assert_eq!(c, "hello");
-}
+fn thinking_streaming() {
+    struct Step {
+        input: &'static str,
+        want_thinking: &'static str,
+        want_content: &'static str,
+        want_state_after: State,
+    }
 
-#[test]
-fn thinking_streaming_cases() {
-    struct Step { input: &'static str, think: &'static str, content: &'static str }
-    let cases: Vec<Vec<Step>> = vec![
-        vec![
-            Step { input: "  abc", think: "", content: "  abc" },
-            Step { input: "def", think: "", content: "def" },
-        ],
-        vec![
-            Step { input: "  <th", think: "", content: "" },
-            Step { input: "in", think: "", content: "" },
-            Step { input: "k>a", think: "a", content: "" },
-        ],
-        vec![
-            Step { input: "<think>abc</th", think: "abc", content: "" },
-            Step { input: "ink>def", think: "", content: "def" },
-        ],
-        vec![
-            Step { input: "<think>abc</th", think: "abc", content: "" },
-            Step { input: "ing>def", think: "</thing>def", content: "" },
-            Step { input: "ghi</thi", think: "ghi", content: "" },
-            Step { input: "nk>jkl", think: "", content: "jkl" },
-        ],
-        vec![
-            Step { input: "  abc <think>def</think> ghi", think: "", content: "  abc <think>def</think> ghi" },
-        ],
-        vec![
-            Step { input: "  <think>abc</think>", think: "abc", content: "" },
-            Step { input: "\n\ndef", think: "", content: "def" },
-        ],
+    struct Case {
+        desc: &'static str,
+        steps: Vec<Step>,
+    }
+
+    let cases = vec![
+        Case {
+            desc: "content without a thinking tag",
+            steps: vec![
+                Step {
+                    input: "  abc",
+                    want_thinking: "",
+                    want_content: "  abc",
+                    want_state_after: State::ThinkingDone,
+                },
+                Step {
+                    input: "def",
+                    want_thinking: "",
+                    want_content: "def",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "content before a thinking tag nerfs the thinking tag",
+            steps: vec![Step {
+                input: "  abc <think>def</think> ghi",
+                want_thinking: "",
+                want_content: "  abc <think>def</think> ghi",
+                want_state_after: State::ThinkingDone,
+            }],
+        },
+        Case {
+            desc: "building up a thinking tag partially",
+            steps: vec![
+                Step {
+                    input: "  <th",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::LookingForOpening,
+                },
+                Step {
+                    input: "in",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::LookingForOpening,
+                },
+                Step {
+                    input: "k>a",
+                    want_thinking: "a",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+            ],
+        },
+        Case {
+            desc: "partial closing tag",
+            steps: vec![
+                Step {
+                    input: "<think>abc</th",
+                    want_thinking: "abc",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+                Step {
+                    input: "ink>def",
+                    want_thinking: "",
+                    want_content: "def",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "partial closing tag fakeout",
+            steps: vec![
+                Step {
+                    input: "<think>abc</th",
+                    want_thinking: "abc",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+                Step {
+                    input: "ing>def",
+                    want_thinking: "</thing>def",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+                Step {
+                    input: "ghi</thi",
+                    want_thinking: "ghi",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+                Step {
+                    input: "nk>jkl",
+                    want_thinking: "",
+                    want_content: "jkl",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "whitespace after thinking tag",
+            steps: vec![Step {
+                input: "  <think>abc</think>\n\ndef",
+                want_thinking: "abc",
+                want_content: "def",
+                want_state_after: State::ThinkingDone,
+            }],
+        },
+        Case {
+            desc: "whitespace after thinking tag (incremental)",
+            steps: vec![
+                Step {
+                    input: "  <think>abc</think>",
+                    want_thinking: "abc",
+                    want_content: "",
+                    want_state_after: State::ThinkingDoneEatingWhitespace,
+                },
+                Step {
+                    input: "\n\ndef",
+                    want_thinking: "",
+                    want_content: "def",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "whitespace after thinking tag with content and more whitespace",
+            steps: vec![
+                Step {
+                    input: "  <think>abc</think>\n\ndef ",
+                    want_thinking: "abc",
+                    want_content: "def ",
+                    want_state_after: State::ThinkingDone,
+                },
+                Step {
+                    input: " ghi",
+                    want_thinking: "",
+                    want_content: " ghi",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "token by token",
+            steps: vec![
+                Step {
+                    input: "<think>",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::ThinkingStartedEatingWhitespace,
+                },
+                Step {
+                    input: "\n",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::ThinkingStartedEatingWhitespace,
+                },
+                Step {
+                    input: "</think>",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::ThinkingDoneEatingWhitespace,
+                },
+                Step {
+                    input: "\n\n",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::ThinkingDoneEatingWhitespace,
+                },
+                Step {
+                    input: "Hi",
+                    want_thinking: "",
+                    want_content: "Hi",
+                    want_state_after: State::ThinkingDone,
+                },
+                Step {
+                    input: " there",
+                    want_thinking: "",
+                    want_content: " there",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
+        Case {
+            desc: "leading thinking whitespace",
+            steps: vec![
+                Step {
+                    input: "  <think>   \t ",
+                    want_thinking: "",
+                    want_content: "",
+                    want_state_after: State::ThinkingStartedEatingWhitespace,
+                },
+                Step {
+                    input: "  these are some ",
+                    want_thinking: "these are some ",
+                    want_content: "",
+                    want_state_after: State::Thinking,
+                },
+                Step {
+                    input: "thoughts </think>  ",
+                    want_thinking: "thoughts ",
+                    want_content: "",
+                    want_state_after: State::ThinkingDoneEatingWhitespace,
+                },
+                Step {
+                    input: "  more content",
+                    want_thinking: "",
+                    want_content: "more content",
+                    want_state_after: State::ThinkingDone,
+                },
+            ],
+        },
     ];
+
     for case in cases {
-        let mut p = Parser::default();
-        p.opening_tag = "<think>".into();
-        p.closing_tag = "</think>".into();
-        for step in case {
-            let (t, c) = p.add_content(step.input);
-            assert_eq!(t, step.think);
-            assert_eq!(c, step.content);
+        let mut parser = Parser::default();
+        parser.opening_tag = "<think>".into();
+        parser.closing_tag = "</think>".into();
+        for (i, step) in case.steps.iter().enumerate() {
+            let (thinking, content) = parser.add_content(step.input);
+            assert_eq!(
+                thinking, step.want_thinking,
+                "case {} (step {}) thinking",
+                case.desc, i
+            );
+            assert_eq!(
+                content, step.want_content,
+                "case {} (step {}) content",
+                case.desc, i
+            );
+            assert_eq!(
+                parser.state(),
+                step.want_state_after,
+                "case {} (step {}) state",
+                case.desc,
+                i
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace the regex-based thinking tag heuristic with an AST-driven parser that tokenizes Go templates and inspects field usage
- expose the thinking parser state API and tighten buffer handling to mirror the Go implementation
- port the Go thinking parser tests, including state assertions, and drop the unused regex dependency

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68c85e4fcae4832fbd1ebdf4d16d6ac7