### PR TITLE
Add Rust integration tests for API and model coverage

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,6 +3,21 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12,16 +27,85 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+
+[[package]]
+name = "api"
+version = "0.1.0"
+dependencies = [
+ "base64 0.21.7",
+ "futures-util",
+ "humantime",
+ "ollama_types",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "time",
+ "tokio",
+ "url",
+ "version",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "backtrace"
+version = "0.3.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
+
+[[package]]
+name = "bumpalo"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "bytes"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
@@ -40,15 +124,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
 name = "crossterm"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f476fe445d41c9e991fd07515a6f463074b782242ccf4a5b7b1d1012e70824df"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "libc",
- "mio",
+ "mio 0.8.11",
  "parking_lot",
  "signal-hook",
  "signal-hook-mio",
@@ -62,6 +162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d630bccd429a5bb5a64b5e94f693bfc48c9f8566418fda4c494cc94f911f87cc"
+dependencies = [
+ "powerfmt",
 ]
 
 [[package]]
@@ -86,6 +195,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "envconfig"
 version = "0.1.0"
 dependencies = [
@@ -95,10 +224,92 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fd99930f64d146689264c637b5af2f0233a933bef0d8570e2526bf9e083192d"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "getrandom"
@@ -112,10 +323,263 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
+name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+
+[[package]]
+name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3efd23720e2049821a693cbc7e65ea87c72f1c58ff2f9522ff332b1491e590"
+dependencies = [
+ "futures-util",
+ "http",
+ "hyper",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+
+[[package]]
+name = "icu_properties"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "potential_utf",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+
+[[package]]
+name = "icu_provider"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92119844f513ffa41556430369ab02c295a3578af21cf945caa3e9e0c2481ac3"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.4",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "js-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0b063578492ceec17683ef2f8c5e89121fbd0b172cbc280635ab7567db2738"
+dependencies = [
+ "once_cell",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "kvcache"
@@ -139,9 +603,15 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
  "libc",
 ]
+
+[[package]]
+name = "litemap"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -183,6 +653,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "mio"
 version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -195,12 +680,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
 dependencies = [
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "ollama_types"
+version = "0.1.0"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -219,11 +737,18 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 name = "oxi_rust"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
+ "api",
+ "base64 0.22.1",
  "cc",
  "envconfig",
  "kvcache",
  "logutil",
+ "once_cell",
  "readline",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]
@@ -250,10 +775,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -274,6 +835,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom",
+]
+
+[[package]]
 name = "readline"
 version = "0.1.0"
 dependencies = [
@@ -286,7 +877,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -318,10 +909,181 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "system-configuration",
+ "tokio",
+ "tokio-rustls",
+ "tokio-util",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+ "webpki-roots",
+ "winreg",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustls"
+version = "0.21.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f56a14d1f48b391359b22f731fd4bd7e43c97f3c50eee276f3aa09c94784d3e"
+dependencies = [
+ "log",
+ "ring",
+ "rustls-webpki",
+ "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.101.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sct"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da046153aa2352493d6cb7da4b6e5c0c057d8a1d0a9aa8560baffdd945acd414"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd6c24dee235d0da097043389623fb913daddf92c76e9f5a1db88607a0bcbd1d"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "659356f9a0cb1e529b24c01e43ad2bdf520ec4ceaf83047b83ddcc2251f96383"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.225"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea936adf78b1f766949a4977b91d2f5595825bd6ec079aa9543ad2685fc4516"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.145"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "sharded-slab"
@@ -355,7 +1117,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
  "signal-hook",
 ]
 
@@ -369,10 +1131,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "syn"
@@ -383,6 +1177,44 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -413,6 +1245,104 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83bde6f1ec10e72d583d91623c939f623002284ef622b87de38cfd546cbf2031"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40868e7c1d2f0b8d73e4a8c7f0ff63af4f6d19be117e90bd73eb1d62cf831c6b"
+
+[[package]]
+name = "time-macros"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30cfb0125f12d9c277f35663a0a33f8c30190f4e4574868a330595412d34ebf3"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokio"
+version = "1.47.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "io-uring",
+ "libc",
+ "mio 1.0.4",
+ "pin-project-lite",
+ "slab",
+ "socket2 0.6.0",
+ "tokio-macros",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28327cf380ac148141087fbfb9de9d7bd4e84ab5d2c28fbc911d753de8a7081"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
@@ -476,10 +1406,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "url"
+version = "2.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "valuable"
@@ -488,10 +1448,124 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
+name = "version"
+version = "0.1.0"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e14915cadd45b529bb8d1f343c4ed0ac1de926144b746e2710f9cd05df6603b"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28d1ba982ca7923fd01448d5c30c6864d0a14109560296a162f80f305fb93bb"
+dependencies = [
+ "bumpalo",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca85039a9b469b38336411d6d6ced91f3fc87109a2a27b0c197663f5144dffe"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "once_cell",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c3d463ae3eff775b0c45df9da45d68837702ac35af998361e2c84e7c5ec1b0d"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb4ce89b08211f923caf51d527662b75bdc9c9c7aab40f86dcb9fb85ac552aa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.101"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f143854a3b13752c6950862c906306adb27c7e839f7414cec8fea35beab624c1"
+dependencies = [
+ "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.78"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77e4b637749ff0d92b8fad63aa1f7cff3cbe125fd49c175cd6345e7272638b12"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "winapi"
@@ -529,6 +1603,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -653,3 +1736,117 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "writeable"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+
+[[package]]
+name = "yoke"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+dependencies = [
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerotrie"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -11,3 +11,12 @@ logutil = { path = "logutil" }
 
 [build-dependencies]
 cc = "1.0"
+
+[dev-dependencies]
+anyhow = "1.0"
+base64 = "0.22"
+once_cell = "1.19"
+serde_json = "1.0"
+tokio = { version = "1.37", features = ["macros", "rt-multi-thread", "time"] }
+api = { path = "api" }
+url = "2.5"

--- a/rust/ffi/hello.c
+++ b/rust/ffi/hello.c
@@ -1,0 +1,3 @@
+int hello_from_c(void) {
+    return 42;
+}

--- a/rust/tests/api_tests.rs
+++ b/rust/tests/api_tests.rs
@@ -1,0 +1,108 @@
+use anyhow::Result;
+use serde_json::json;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{
+    build_chat_request, build_generate_request, IntegrationTest, ModelStatus, BLUE_SKY_KEYWORDS,
+};
+
+fn contains_any(text: &str, expected: &[&str]) -> bool {
+    let lower = text.to_lowercase();
+    expected.iter().any(|needle| lower.contains(needle))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_api_generate() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let mut req = build_generate_request("why is the sky blue? be brief");
+    req.options.insert("temperature".into(), json!(0));
+    req.options.insert("seed".into(), json!(123));
+
+    let outcome = ctx.generate(req).await?;
+    assert!(
+        !outcome.responses.is_empty(),
+        "no streaming updates returned"
+    );
+    assert!(
+        contains_any(&outcome.full_text, BLUE_SKY_KEYWORDS),
+        "response did not mention sky details: {}",
+        outcome.full_text
+    );
+
+    let final_resp = outcome.final_response().expect("final response");
+    assert!(!final_resp.model.is_empty(), "model field missing");
+    assert!(
+        !final_resp.context.is_empty(),
+        "context should not be empty"
+    );
+    assert!(
+        final_resp.metrics.total_duration.is_some(),
+        "missing total duration"
+    );
+    assert!(
+        final_resp.metrics.load_duration.is_some(),
+        "missing load duration"
+    );
+    assert!(
+        final_resp.metrics.eval_duration.is_some(),
+        "missing eval duration"
+    );
+
+    let running = ctx.list_running().await?;
+    assert!(
+        running
+            .models
+            .iter()
+            .any(|m| m.name.contains(ctx.smol_model())),
+        "model should be listed as running"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_api_chat() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let mut req = build_chat_request("why is the sky blue? be brief");
+    req.options.insert("temperature".into(), json!(0));
+    req.options.insert("seed".into(), json!(321));
+
+    let outcome = ctx.chat(req).await?;
+    assert!(!outcome.responses.is_empty(), "no chat responses received");
+    assert!(
+        contains_any(&outcome.transcript, BLUE_SKY_KEYWORDS),
+        "chat response missing expected keywords: {}",
+        outcome.transcript
+    );
+
+    let final_resp = outcome.responses.last().expect("final chat");
+    assert!(!final_resp.model.is_empty(), "model field missing");
+    assert!(
+        final_resp.metrics.total_duration.is_some(),
+        "missing total duration"
+    );
+
+    Ok(())
+}

--- a/rust/tests/basic_tests.rs
+++ b/rust/tests/basic_tests.rs
@@ -1,0 +1,62 @@
+use anyhow::Result;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{build_generate_request, IntegrationTest, ModelStatus, BLUE_SKY_KEYWORDS};
+
+fn contains_any(text: &str, expected: &[&str]) -> bool {
+    let lower = text.to_lowercase();
+    expected.iter().any(|needle| lower.contains(needle))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_blue_sky_generation() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let req = build_generate_request("why is the sky blue?");
+    let outcome = ctx.generate(req).await?;
+    assert!(
+        contains_any(&outcome.full_text, BLUE_SKY_KEYWORDS),
+        "model response missing expected keywords: {}",
+        outcome.full_text
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_unicode_generation() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let req = build_generate_request("Provide a joyful response with multiple emoji icons");
+    let outcome = ctx.generate(req).await?;
+    let has_emoji = ["😀", "😁", "😂", "😊", "😄", "😃"]
+        .iter()
+        .any(|emoji| outcome.full_text.contains(emoji));
+    assert!(
+        has_emoji,
+        "expected emoji output, got: {}",
+        outcome.full_text
+    );
+
+    Ok(())
+}

--- a/rust/tests/common/mod.rs
+++ b/rust/tests/common/mod.rs
@@ -1,0 +1,319 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use anyhow::{anyhow, Context, Result};
+use api::client::Error as ApiError;
+use api::{
+    ChatRequest, ChatResponse, Client, EmbeddingRequest, EmbeddingResponse, GenerateRequest,
+    GenerateResponse, ListResponse, Message, ProcessResponse, PullRequest, ShowRequest,
+    ShowResponse,
+};
+use base64::engine::general_purpose::STANDARD as BASE64_STANDARD;
+use base64::Engine;
+use once_cell::sync::Lazy;
+use serde_json::json;
+use tokio::time::timeout;
+use url::Url;
+
+static DEFAULT_MODEL: Lazy<String> = Lazy::new(|| {
+    std::env::var("OLLAMA_TEST_SMOL_MODEL").unwrap_or_else(|_| "llama3.2:1b".to_string())
+});
+
+pub const BLUE_SKY_KEYWORDS: &[&str] = &[
+    "rayleigh",
+    "scatter",
+    "scattering",
+    "atmosphere",
+    "nitrogen",
+    "oxygen",
+];
+
+pub const DEFAULT_GENERATE_TIMEOUT: Duration = Duration::from_secs(120);
+
+pub enum ModelStatus {
+    Ready,
+    Skipped,
+}
+
+pub struct GenerateOutcome {
+    pub responses: Vec<GenerateResponse>,
+    pub full_text: String,
+    pub context: Vec<i32>,
+}
+
+impl GenerateOutcome {
+    pub fn final_response(&self) -> Option<&GenerateResponse> {
+        self.responses.last()
+    }
+}
+
+pub struct ChatOutcome {
+    pub responses: Vec<ChatResponse>,
+    pub transcript: String,
+}
+
+impl ChatOutcome {
+    pub fn final_message(&self) -> Option<&Message> {
+        self.responses.last().map(|resp| &resp.message)
+    }
+}
+
+#[derive(Clone)]
+pub struct IntegrationTest {
+    client: Client,
+    base: Url,
+    smol_model: String,
+}
+
+impl IntegrationTest {
+    pub async fn new() -> Result<Option<Self>> {
+        let client = match Client::from_env() {
+            Ok(client) => client,
+            Err(err) => return Err(to_anyhow(err).context("failed to create API client")),
+        };
+        let base = client.base().clone();
+        match client.heartbeat().await {
+            Ok(()) => Ok(Some(Self {
+                client,
+                base,
+                smol_model: DEFAULT_MODEL.clone(),
+            })),
+            Err(ApiError::Http(err)) if err.is_connect() || err.is_timeout() => {
+                println!(
+                    "skipping integration test: unable to reach ollama server at {} ({err})",
+                    base
+                );
+                Ok(None)
+            }
+            Err(err) => Err(to_anyhow(err).context("failed heartbeat")),
+        }
+    }
+
+    pub fn client(&self) -> Client {
+        self.client.clone()
+    }
+
+    pub fn smol_model(&self) -> &str {
+        &self.smol_model
+    }
+
+    pub fn base_url(&self) -> &Url {
+        &self.base
+    }
+
+    pub async fn ensure_model(&self, model: &str) -> Result<ModelStatus> {
+        match self
+            .client
+            .show(&ShowRequest {
+                model: model.to_string(),
+                ..Default::default()
+            })
+            .await
+        {
+            Ok(_) => Ok(ModelStatus::Ready),
+            Err(ApiError::Status(status)) if status.status_code == 404 => {
+                if std::env::var("OLLAMA_SKIP_PULL").is_ok() {
+                    println!(
+                        "skipping test because model {model} is missing and OLLAMA_SKIP_PULL is set"
+                    );
+                    return Ok(ModelStatus::Skipped);
+                }
+                let pull_req = PullRequest {
+                    model: model.to_string(),
+                    name: model.to_string(),
+                    stream: Some(true),
+                    ..Default::default()
+                };
+                let last_update = Arc::new(Mutex::new(Instant::now()));
+                let guard = last_update.clone();
+                let pull_future = self.client.pull(&pull_req, move |_| {
+                    if let Ok(mut ts) = guard.lock() {
+                        *ts = Instant::now();
+                    }
+                    Ok(())
+                });
+                tokio::pin!(pull_future);
+                let stall_limit = Duration::from_secs(60);
+                loop {
+                    let progress_deadline = {
+                        let ts = last_update.lock().unwrap();
+                        *ts + stall_limit
+                    };
+                    let wait_duration = progress_deadline.saturating_duration_since(Instant::now());
+                    match timeout(wait_duration.max(Duration::from_secs(1)), &mut pull_future).await
+                    {
+                        Ok(result) => {
+                            result.map_err(to_anyhow).context("pull failed")?;
+                            break;
+                        }
+                        Err(_) => {
+                            if Instant::now() >= progress_deadline {
+                                return Err(anyhow!(
+                                    "pull stalled for model {model}. set OLLAMA_SKIP_PULL=1 to skip"
+                                ));
+                            }
+                        }
+                    }
+                }
+                Ok(ModelStatus::Ready)
+            }
+            Err(err) => Err(to_anyhow(err).context(format!("failed to inspect model {model}"))),
+        }
+    }
+
+    pub async fn generate(&self, mut req: GenerateRequest) -> Result<GenerateOutcome> {
+        if req.model.is_empty() {
+            req.model = self.smol_model.clone();
+        }
+        if req.stream.is_none() {
+            req.stream = Some(true);
+        }
+        let mut responses = Vec::new();
+        let mut aggregate = String::new();
+        let mut context = Vec::new();
+        let client = self.client.clone();
+        timeout(
+            DEFAULT_GENERATE_TIMEOUT,
+            client.generate(&req, |resp| {
+                context = resp.context.clone();
+                aggregate.push_str(&resp.response);
+                responses.push(resp);
+                Ok(())
+            }),
+        )
+        .await
+        .context("generate timed out")?
+        .map_err(to_anyhow)?;
+        Ok(GenerateOutcome {
+            responses,
+            full_text: aggregate,
+            context,
+        })
+    }
+
+    pub async fn chat(&self, mut req: ChatRequest) -> Result<ChatOutcome> {
+        if req.model.is_empty() {
+            req.model = self.smol_model.clone();
+        }
+        if req.stream.is_none() {
+            req.stream = Some(true);
+        }
+        let mut responses = Vec::new();
+        let mut transcript = String::new();
+        let client = self.client.clone();
+        timeout(
+            DEFAULT_GENERATE_TIMEOUT,
+            client.chat(&req, |resp| {
+                transcript.push_str(&resp.message.content);
+                responses.push(resp);
+                Ok(())
+            }),
+        )
+        .await
+        .context("chat timed out")?
+        .map_err(to_anyhow)?;
+        Ok(ChatOutcome {
+            responses,
+            transcript,
+        })
+    }
+
+    pub async fn embeddings(&self, req: EmbeddingRequest) -> Result<EmbeddingResponse> {
+        timeout(
+            DEFAULT_GENERATE_TIMEOUT,
+            self.client.clone().embeddings(&req),
+        )
+        .await
+        .context("embeddings timed out")?
+        .map_err(to_anyhow)
+    }
+
+    pub async fn show(&self, model: &str) -> Result<ShowResponse> {
+        self.client
+            .clone()
+            .show(&ShowRequest {
+                model: model.to_string(),
+                ..Default::default()
+            })
+            .await
+            .map_err(to_anyhow)
+    }
+
+    pub async fn list(&self) -> Result<ListResponse> {
+        self.client.clone().list().await.map_err(to_anyhow)
+    }
+
+    pub async fn list_running(&self) -> Result<ProcessResponse> {
+        self.client.clone().list_running().await.map_err(to_anyhow)
+    }
+}
+
+pub fn build_generate_request(prompt: &str) -> GenerateRequest {
+    let mut req = GenerateRequest::default();
+    req.model = DEFAULT_MODEL.clone();
+    req.prompt = prompt.to_string();
+    req.stream = Some(true);
+    req.keep_alive = Some(api::Duration(DEFAULT_GENERATE_TIMEOUT));
+    req.options.insert("temperature".into(), json!(0));
+    req.options.insert("seed".into(), json!(123));
+    req
+}
+
+pub fn build_chat_request(prompt: &str) -> ChatRequest {
+    let mut req = ChatRequest::default();
+    req.model = DEFAULT_MODEL.clone();
+    req.messages.push(Message {
+        role: "user".into(),
+        content: prompt.to_string(),
+        ..Default::default()
+    });
+    req.stream = Some(true);
+    req.keep_alive = Some(api::Duration(DEFAULT_GENERATE_TIMEOUT));
+    req.options.insert("temperature".into(), json!(0));
+    req.options.insert("seed".into(), json!(123));
+    req
+}
+
+pub fn list_library_models() -> &'static [&'static str] {
+    const MODELS: &[&str] = &[
+        "gpt-oss:20b",
+        "gemma3n:e2b",
+        "mistral-small3.2:latest",
+        "deepseek-r1:1.5b",
+        "llama3.2-vision:latest",
+        "qwen2.5-coder:latest",
+        "qwen3:0.6b",
+        "gemma3:1b",
+    ];
+    MODELS
+}
+
+pub fn list_embedding_models() -> &'static [&'static str] {
+    const MODELS: &[&str] = &["all-minilm", "bge-large", "mxbai-embed-large"];
+    MODELS
+}
+
+pub fn sample_image() -> Vec<u8> {
+    // 1x1 transparent PNG
+    const BASE64_IMAGE: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMBAAGoS0cAAAAASUVORK5CYII=";
+    BASE64_STANDARD
+        .decode(BASE64_IMAGE)
+        .expect("invalid embedded image")
+}
+
+fn to_anyhow(err: ApiError) -> anyhow::Error {
+    match err {
+        ApiError::Http(err) => anyhow::Error::new(err),
+        ApiError::Url(err) => anyhow::Error::new(err),
+        ApiError::Json(err) => anyhow::Error::new(err),
+        ApiError::Status(status) => anyhow!(
+            "{} ({}): {}",
+            status.status,
+            status.status_code,
+            status.error_message
+        ),
+    }
+}

--- a/rust/tests/concurrency_tests.rs
+++ b/rust/tests/concurrency_tests.rs
@@ -1,0 +1,55 @@
+use anyhow::Result;
+use tokio::task::JoinSet;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{build_generate_request, IntegrationTest, ModelStatus};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_concurrent_generate() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let prompts = vec![
+        (
+            "why is the ocean blue? explain succinctly",
+            vec!["rayleigh", "scatter", "water"],
+        ),
+        (
+            "how do rainbows form?",
+            vec!["prism", "refraction", "light"],
+        ),
+        (
+            "summarize the composition of air",
+            vec!["nitrogen", "oxygen", "carbon"],
+        ),
+    ];
+
+    let mut jobs = JoinSet::new();
+    for (prompt, keywords) in prompts {
+        let ctx_clone = ctx.clone();
+        let req = build_generate_request(prompt);
+        jobs.spawn(async move {
+            let outcome = ctx_clone.generate(req).await?;
+            let output = outcome.full_text.to_lowercase();
+            let success = keywords.iter().any(|kw| output.contains(kw));
+            anyhow::ensure!(success, "response missing expected keywords: {}", output);
+            Ok::<(), anyhow::Error>(())
+        });
+    }
+
+    while let Some(result) = jobs.join_next().await {
+        result??;
+    }
+
+    Ok(())
+}

--- a/rust/tests/context_tests.rs
+++ b/rust/tests/context_tests.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use api::Message;
+use common::{
+    build_chat_request, build_generate_request, IntegrationTest, ModelStatus, BLUE_SKY_KEYWORDS,
+};
+
+fn contains_any(text: &str, expected: &[&str]) -> bool {
+    let lower = text.to_lowercase();
+    expected.iter().any(|needle| lower.contains(needle))
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_generate_with_history() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let first = ctx
+        .generate(build_generate_request(
+            "why is the sky blue? explain briefly",
+        ))
+        .await?;
+    assert!(contains_any(&first.full_text, BLUE_SKY_KEYWORDS));
+
+    let mut follow_up = build_generate_request("tell me more!");
+    follow_up.context = Some(first.context.clone());
+    let follow = ctx.generate(follow_up).await?;
+    assert!(!follow.full_text.is_empty(), "follow up response was empty");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_chat_with_history() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let first_prompt = "why is the sky blue?";
+    let first = ctx.chat(build_chat_request(first_prompt)).await?;
+    let assistant = first
+        .responses
+        .last()
+        .map(|resp| resp.message.clone())
+        .unwrap_or(Message {
+            role: "assistant".into(),
+            content: String::new(),
+            thinking: String::new(),
+            images: Vec::new(),
+            tool_calls: Vec::new(),
+            tool_name: String::new(),
+        });
+
+    let mut follow = build_chat_request("tell me more about atmospheric scattering");
+    follow.messages.insert(
+        0,
+        Message {
+            role: "user".into(),
+            content: first_prompt.to_string(),
+            thinking: String::new(),
+            images: Vec::new(),
+            tool_calls: Vec::new(),
+            tool_name: String::new(),
+        },
+    );
+    follow.messages.insert(1, assistant);
+    let second = ctx.chat(follow).await?;
+    assert!(contains_any(&second.transcript, BLUE_SKY_KEYWORDS));
+
+    Ok(())
+}

--- a/rust/tests/embed_tests.rs
+++ b/rust/tests/embed_tests.rs
@@ -1,0 +1,45 @@
+use anyhow::Result;
+use serde_json::json;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use api::{Duration as ApiDuration, EmbeddingRequest};
+use common::{IntegrationTest, ModelStatus};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_text_embeddings() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    let model = "all-minilm";
+    if matches!(ctx.ensure_model(model).await?, ModelStatus::Skipped) {
+        return Ok(());
+    }
+
+    let mut req = EmbeddingRequest::default();
+    req.model = model.into();
+    req.prompt = "why is the sky blue?".into();
+    req.keep_alive = Some(ApiDuration(common::DEFAULT_GENERATE_TIMEOUT));
+    req.options.insert("seed".into(), json!(123));
+
+    let resp = ctx.embeddings(req).await?;
+    assert!(
+        !resp.embedding.is_empty(),
+        "embedding vector should not be empty"
+    );
+
+    let magnitude: f64 = resp
+        .embedding
+        .iter()
+        .map(|v| (*v as f64) * (*v as f64))
+        .sum::<f64>()
+        .sqrt();
+    assert!(
+        magnitude.is_finite(),
+        "embedding magnitude should be finite"
+    );
+
+    Ok(())
+}

--- a/rust/tests/library_models_tests.rs
+++ b/rust/tests/library_models_tests.rs
@@ -1,0 +1,28 @@
+#[path = "common/mod.rs"]
+mod common;
+
+#[test]
+fn test_library_model_list_contains_expected_entries() {
+    let models = common::list_library_models();
+    assert!(
+        !models.is_empty(),
+        "expected curated model list to be non-empty"
+    );
+    assert!(
+        models.iter().any(|&m| m.contains("llama3.2")),
+        "llama-based model missing from curated list"
+    );
+    assert!(
+        models.iter().any(|&m| m.starts_with("gemma")),
+        "gemma entry missing from curated list"
+    );
+}
+
+#[test]
+fn test_library_embedding_models_include_minilm() {
+    let models = common::list_embedding_models();
+    assert!(
+        models.contains(&"all-minilm"),
+        "all-minilm should be part of embedding test set"
+    );
+}

--- a/rust/tests/llm_image_tests.rs
+++ b/rust/tests/llm_image_tests.rs
@@ -1,0 +1,34 @@
+use anyhow::Result;
+use serde_json::json;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{build_generate_request, IntegrationTest, ModelStatus};
+
+#[tokio::test(flavor = "multi_thread")]
+#[ignore = "requires optional vision models"]
+async fn test_vision_model_reading_text() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    let model = "llama3.2-vision:latest";
+    if matches!(ctx.ensure_model(model).await?, ModelStatus::Skipped) {
+        return Ok(());
+    }
+
+    let mut req = build_generate_request("describe the text in this image");
+    req.model = model.into();
+    req.images.push(common::sample_image());
+    req.options.insert("temperature".into(), json!(0));
+    req.options.insert("seed".into(), json!(42));
+
+    let outcome = ctx.generate(req).await?;
+    assert!(
+        !outcome.full_text.is_empty(),
+        "vision model produced empty response"
+    );
+
+    Ok(())
+}

--- a/rust/tests/max_queue_tests.rs
+++ b/rust/tests/max_queue_tests.rs
@@ -1,0 +1,6 @@
+#[test]
+#[ignore = "pending queue stress strategy"]
+fn test_max_queue_placeholder() {
+    // The original Go integration test requires a locally spawned server with a custom queue size.
+    // Reproducing that flow in Rust will require additional server lifecycle tooling.
+}

--- a/rust/tests/model_arch_tests.rs
+++ b/rust/tests/model_arch_tests.rs
@@ -1,0 +1,37 @@
+use anyhow::Result;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{IntegrationTest, ModelStatus};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_show_reports_architecture_details() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let info = ctx.show(ctx.smol_model()).await?;
+    let arch_key = "general.architecture";
+    let Some(arch_value) = info.model_info.get(arch_key).and_then(|v| v.as_str()) else {
+        anyhow::bail!("show response missing {arch_key}");
+    };
+    assert!(
+        !arch_value.is_empty(),
+        "architecture string should not be empty"
+    );
+
+    let context_key = format!("{arch_value}.context_length");
+    if let Some(len) = info.model_info.get(&context_key).and_then(|v| v.as_f64()) {
+        assert!(len > 0.0, "context length should be positive");
+    }
+
+    Ok(())
+}

--- a/rust/tests/model_perf_tests.rs
+++ b/rust/tests/model_perf_tests.rs
@@ -1,0 +1,44 @@
+use anyhow::Result;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{build_generate_request, IntegrationTest, ModelStatus};
+
+const SHAKESPEARE: &str = include_str!("../../integration/testdata/shakespeare.txt");
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_long_prompt_metrics() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let excerpt = &SHAKESPEARE[..SHAKESPEARE.len().min(1024)];
+    let req = build_generate_request(&format!("summarize the following: {excerpt}"));
+    let outcome = ctx.generate(req).await?;
+    let final_resp = outcome.final_response().expect("final response");
+
+    assert!(
+        final_resp
+            .metrics
+            .eval_count
+            .map_or(false, |count| count > 0),
+        "expected non-zero eval count"
+    );
+    assert!(
+        final_resp
+            .metrics
+            .eval_duration
+            .map_or(false, |duration| duration > 0),
+        "expected eval duration to be populated"
+    );
+
+    Ok(())
+}

--- a/rust/tests/quantization_tests.rs
+++ b/rust/tests/quantization_tests.rs
@@ -1,0 +1,28 @@
+use anyhow::Result;
+
+#[path = "common/mod.rs"]
+mod common;
+
+use common::{IntegrationTest, ModelStatus};
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_quantization_level_exposed() -> Result<()> {
+    let Some(ctx) = IntegrationTest::new().await? else {
+        return Ok(());
+    };
+
+    if matches!(
+        ctx.ensure_model(ctx.smol_model()).await?,
+        ModelStatus::Skipped
+    ) {
+        return Ok(());
+    }
+
+    let info = ctx.show(ctx.smol_model()).await?;
+    assert!(
+        !info.details.quantization_level.is_empty(),
+        "quantization level should be reported"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add shared Rust test utilities for integration scenarios
- port integration coverage to async Rust tests for API, context, embeddings, performance, and quantization flows
- add a minimal C helper to satisfy the existing build script

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_68c96d940e08832f93b3faa7017bd667