### PR TITLE
Update Docker build to use Rust artifacts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -102,16 +102,20 @@ WORKDIR /work/ollama
 ARG RUST_VERSION=1.80.1
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain ${RUST_VERSION} --profile minimal
 ENV PATH=/root/.cargo/bin:$PATH
+ARG RUST_TARGETS=""
+RUN /bin/sh -c 'set -eux; if [ -n "${RUST_TARGETS}" ]; then for target in ${RUST_TARGETS}; do rustup target add "${target}"; done; fi'
 ARG VERSION
 ENV VERSION=${VERSION}
+ARG CARGO_FEATURES=""
+ENV CARGO_FEATURES=${CARGO_FEATURES}
 COPY . .
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    cargo fetch
+    cargo fetch --locked
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
-    cargo build --release --bin ollama
-RUN install -Dm755 target/release/ollama /bin/ollama
+    /bin/sh -c 'set -eux; if [ -n "${CARGO_FEATURES}" ]; then cargo build --release --bin ollama --features "${CARGO_FEATURES}"; else cargo build --release --bin ollama; fi'
+RUN /bin/sh -c 'set -eux; mkdir -p target/release/runtime-libs; find target/release -maxdepth 1 -type f -name "*.so" -exec cp {} target/release/runtime-libs/ \;; find target/release/deps -maxdepth 1 -type f -name "*.so" -exec cp {} target/release/runtime-libs/ \;'
 
 FROM --platform=linux/amd64 scratch AS amd64
 # COPY --from=cuda-11 dist/lib/ollama/ /lib/ollama/
@@ -130,7 +134,8 @@ COPY --from=rocm-6 dist/lib/ollama /lib/ollama
 
 FROM ${FLAVOR} AS archive
 COPY --from=cpu dist/lib/ollama /lib/ollama
-COPY --from=build /bin/ollama /bin/ollama
+COPY --from=build /work/ollama/target/release/ollama /bin/ollama
+COPY --from=build /work/ollama/target/release/runtime-libs/ /lib/ollama/
 
 FROM ubuntu:24.04
 RUN apt-get update \

--- a/docs/development.md
+++ b/docs/development.md
@@ -104,6 +104,22 @@ cargo run -- serve
 docker build .
 ```
 
+Optional build arguments are available to tune the Rust compilation that runs in
+the Docker builder stage:
+
+- `CARGO_FEATURES` – comma-separated list passed to `cargo build --features`.
+  Enable `ml/tch` for the Torch-based runtime and add `tch/cuda` or
+  `tch/rocm` to match the GPU backend that is being packaged.
+- `RUST_TARGETS` – space-separated `rustup target add` values that are
+  installed before building (useful for cross-compilation).
+
+Examples:
+
+```shell
+docker build --build-arg CARGO_FEATURES=ml/tch .
+docker build --build-arg FLAVOR=rocm --build-arg CARGO_FEATURES=ml/tch,tch/rocm .
+```
+
 ### ROCm
 
 ```shell

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -5,8 +5,16 @@ export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long
 PLATFORM=${PLATFORM:-"linux/arm64,linux/amd64"}
 DOCKER_ORG=${DOCKER_ORG:-"ollama"}
 FINAL_IMAGE_REPO=${FINAL_IMAGE_REPO:-"${DOCKER_ORG}/ollama"}
-OLLAMA_COMMON_BUILD_ARGS="--build-arg=VERSION"
+CARGO_FEATURES=${CARGO_FEATURES:-""}
+RUST_TARGETS=${RUST_TARGETS:-""}
+OLLAMA_COMMON_BUILD_ARGS="--build-arg=VERSION --build-arg=CARGO_FEATURES=${CARGO_FEATURES} --build-arg=RUST_TARGETS=${RUST_TARGETS}"
 
 echo "Building Ollama"
 echo "VERSION=$VERSION"
 echo "PLATFORM=$PLATFORM"
+if [ -n "$CARGO_FEATURES" ]; then
+    echo "CARGO_FEATURES=$CARGO_FEATURES"
+fi
+if [ -n "$RUST_TARGETS" ]; then
+    echo "RUST_TARGETS=$RUST_TARGETS"
+fi


### PR DESCRIPTION
## Summary
- configure the Docker builder stage with rustup, optional target installation, and feature-aware cargo builds
- copy the Rust release binary and any runtime libraries from `target/release` into the final image while preserving the CMake GPU artifacts
- surface the new Rust build arguments through the build scripts and documentation

## Testing
- cargo fmt --all --check

------
https://chatgpt.com/codex/tasks/task_b_68cc169fe17c832f9a8bf339c73b2fc0