### PR TITLE
Align build tooling with Rust metadata and outputs

### DIFF
--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -8,8 +8,42 @@ usage() {
     exit 1
 }
 
-export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
+SCRIPT_DIR=$(cd "$(dirname "$0")" && pwd)
+if [ -z "${VERSION:-}" ] || [ -z "${VERSION_SEMVER:-}" ] || [ -z "${VERSION_METADATA:-}" ]; then
+    OLLAMA_ENV_QUIET=1 . "$SCRIPT_DIR/env.sh"
+    unset OLLAMA_ENV_QUIET
+else
+    # Ensure helper variables are initialised when env.sh is not sourced.
+    CARGO_FEATURES=${CARGO_FEATURES:-""}
+fi
+export VERSION
+export VERSION_SEMVER=${VERSION_SEMVER:-${VERSION%%+*}}
+export VERSION_METADATA=${VERSION_METADATA:-$VERSION}
 export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:-11.3}
+
+collect_runtime_libs() {
+    target_triple=$1
+    pattern=$2
+    destination=$3
+
+    runtime_dir="target/${target_triple}/release/runtime-libs"
+    rm -rf "$runtime_dir"
+    mkdir -p "$runtime_dir"
+
+    for search_dir in "target/${target_triple}/release" "target/${target_triple}/release/deps"; do
+        if [ -d "$search_dir" ]; then
+            find "$search_dir" -maxdepth 1 -type f -name "$pattern" -exec cp {} "$runtime_dir"/ \;
+        fi
+    done
+
+    if [ -n "$(ls -A "$runtime_dir" 2>/dev/null)" ]; then
+        mkdir -p "$destination"
+        for lib in "$runtime_dir"/*; do
+            [ -f "$lib" ] || continue
+            install -m755 "$lib" "$destination/$(basename "$lib")"
+        done
+    fi
+}
 
 ARCHS="arm64 amd64"
 while getopts "a:h" OPTION; do
@@ -34,8 +68,13 @@ _build_darwin() {
         esac
 
         rustup target add "$TARGET_TRIPLE" >/dev/null 2>&1 || true
-        cargo build --release --bin ollama --target "$TARGET_TRIPLE"
+        if [ -n "$CARGO_FEATURES" ]; then
+            cargo build --release --bin ollama --target "$TARGET_TRIPLE" --features "$CARGO_FEATURES"
+        else
+            cargo build --release --bin ollama --target "$TARGET_TRIPLE"
+        fi
         install -Dm755 "target/$TARGET_TRIPLE/release/ollama" "$INSTALL_PREFIX/ollama"
+        collect_runtime_libs "$TARGET_TRIPLE" "*.dylib" "$INSTALL_PREFIX/lib/ollama"
 
         if [ "$ARCH" = "amd64" ]; then
             status "Building darwin $ARCH dynamic backends"
@@ -82,7 +121,16 @@ _build_macapp() {
         npm run --prefix macapp make
     fi
 
-    mv ./macapp/out/make/zip/darwin/universal/Ollama-darwin-universal-$VERSION.zip dist/Ollama-darwin.zip
+    MACAPP_VERSION=${VERSION_SEMVER:-${VERSION%%+*}}
+    MACAPP_ZIP="./macapp/out/make/zip/darwin/universal/Ollama-darwin-universal-${MACAPP_VERSION}.zip"
+    if [ ! -f "$MACAPP_ZIP" ]; then
+        MACAPP_ZIP="./macapp/out/make/zip/darwin/universal/Ollama-darwin-universal-${VERSION}.zip"
+    fi
+    if [ ! -f "$MACAPP_ZIP" ]; then
+        echo "Unable to locate packaged app for version ${MACAPP_VERSION} or ${VERSION}" >&2
+        exit 1
+    fi
+    mv "$MACAPP_ZIP" dist/Ollama-darwin.zip
 }
 
 if [ "$#" -eq 0 ]; then

--- a/scripts/build_windows.ps1
+++ b/scripts/build_windows.ps1
@@ -49,22 +49,87 @@ function checkEnv() {
         default { throw "Unsupported TARGET_ARCH: $script:TARGET_ARCH" }
     }
     Write-Output "Checking version"
+    $cargoPackage = if ($env:CARGO_PACKAGE_NAME) { $env:CARGO_PACKAGE_NAME } else { "oxi-llama" }
+    $cargoVersion = ""
+    try {
+        $pkgId = cargo pkgid -p $cargoPackage 2>$null
+        if ($pkgId) {
+            $cargoVersion = ($pkgId -split '#')[-1]
+        }
+    } catch {}
+
+    $gitDescribe = ""
+    try {
+        $gitDescribe = (git describe --tags --first-parent --abbrev=7 --long --dirty --always 2>$null).Trim()
+        if ($gitDescribe.StartsWith('v')) {
+            $gitDescribe = $gitDescribe.Substring(1)
+        }
+    } catch {}
+
+    $metadata = ""
+    if ($cargoVersion -and $gitDescribe) {
+        if ($gitDescribe.StartsWith($cargoVersion + "-")) {
+            $metadata = $gitDescribe.Substring($cargoVersion.Length + 1)
+        } else {
+            $metadata = $gitDescribe
+        }
+    } elseif ($gitDescribe) {
+        $metadata = $gitDescribe
+    }
+    if ($metadata) {
+        $metadata = $metadata.Replace('-', '.')
+    }
+
     if (!$env:VERSION) {
-        $data=(git describe --tags --first-parent --abbrev=7 --long --dirty --always)
-        $pattern="v(.+)"
-        if ($data -match $pattern) {
-            $script:VERSION=$matches[1]
+        if ($cargoVersion) {
+            if ($metadata) {
+                $script:VERSION = "$cargoVersion+$metadata"
+            } else {
+                $script:VERSION = $cargoVersion
+            }
+        } elseif ($gitDescribe) {
+            $script:VERSION = $gitDescribe
         }
     } else {
-        $script:VERSION=$env:VERSION
+        $script:VERSION = $env:VERSION
     }
-    $pattern = "(\d+[.]\d+[.]\d+).*"
-    if ($script:VERSION -match $pattern) {
-        $script:PKG_VERSION=$matches[1]
+    if (-not $script:VERSION) {
+        $script:VERSION = "0.0.0"
+    }
+
+    if (-not $script:VERSION_SEMVER) {
+        if ($cargoVersion) {
+            $script:VERSION_SEMVER = $cargoVersion
+        } else {
+            $script:VERSION_SEMVER = ($script:VERSION -split '\+')[0]
+        }
+    }
+
+    if (-not $script:VERSION_METADATA) {
+        if ($metadata) {
+            $script:VERSION_METADATA = $metadata
+        } elseif ($gitDescribe) {
+            $script:VERSION_METADATA = $gitDescribe.Replace('-', '.')
+        } else {
+            $script:VERSION_METADATA = $script:VERSION
+        }
+    }
+
+    if ($script:VERSION_SEMVER) {
+        $script:PKG_VERSION = $script:VERSION_SEMVER
     } else {
-        $script:PKG_VERSION="0.0.0"
+        $pattern = "(\d+[.]\d+[.]\d+).*"
+        if ($script:VERSION -match $pattern) {
+            $script:PKG_VERSION=$matches[1]
+        } else {
+            $script:PKG_VERSION="0.0.0"
+        }
     }
+
     write-host "Building Ollama $script:VERSION with package version $script:PKG_VERSION"
+    if ($script:VERSION_METADATA -and $script:VERSION_METADATA -ne $script:VERSION) {
+        write-host "Version metadata $script:VERSION_METADATA"
+    }
 
     # Note: Windows Kits 10 signtool crashes with GCP's plugin
     if ($null -eq $env:SIGN_TOOL) {
@@ -79,6 +144,35 @@ function checkEnv() {
         write-host "Code signing disabled - please set KEY_CONTAINERS to sign and copy ollama_inc.crt to the top of the source tree"
     }
     $script:JOBS=((Get-CimInstance Win32_ComputerSystem).NumberOfLogicalProcessors)
+}
+
+
+function CopyRuntimeLibraries($targetTriple, $destination) {
+    $targetRoot = Join-Path "target" $targetTriple
+    $releaseDir = Join-Path $targetRoot "release"
+    $runtimeDir = Join-Path $releaseDir "runtime-libs"
+    if (Test-Path $runtimeDir) {
+        Remove-Item -Path $runtimeDir -Recurse -Force
+    }
+    New-Item -ItemType Directory -Path $runtimeDir -Force | Out-Null
+
+    $searchDirs = @($releaseDir, (Join-Path $releaseDir "deps"))
+    foreach ($dir in $searchDirs) {
+        if (Test-Path $dir) {
+            Get-ChildItem -Path $dir -Filter "*.dll" -File | Copy-Item -Destination $runtimeDir -Force
+        }
+    }
+
+    if (Test-Path $runtimeDir) {
+        $libs = Get-ChildItem -Path $runtimeDir -File -ErrorAction SilentlyContinue
+        if ($libs) {
+            $destDir = Join-Path (Join-Path $destination "lib") "ollama"
+            if (-not (Test-Path $destDir)) {
+                New-Item -ItemType Directory -Path $destDir -Force | Out-Null
+            }
+            $libs | Copy-Item -Destination $destDir -Force
+        }
+    }
 }
 
 
@@ -191,10 +285,17 @@ function buildOllama() {
     mkdir -Force -path "${script:DIST_DIR}\"
     write-host "Building ollama CLI"
     $env:VERSION=$script:VERSION
+    $env:VERSION_SEMVER=$script:VERSION_SEMVER
+    $env:VERSION_METADATA=$script:VERSION_METADATA
     rustup target add $script:RustTarget | Out-Null
-    cargo build --release --bin ollama --target $script:RustTarget
+    $cargoArgs = @("build", "--release", "--bin", "ollama", "--target", $script:RustTarget)
+    if ($env:CARGO_FEATURES) {
+        $cargoArgs += @("--features", $env:CARGO_FEATURES)
+    }
+    cargo @cargoArgs
     if ($LASTEXITCODE -ne 0) { exit($LASTEXITCODE)}
     Copy-Item "${script:SRC_DIR}\target\$($script:RustTarget)\release\ollama.exe" "${script:DIST_DIR}\" -Force
+    CopyRuntimeLibraries -targetTriple $script:RustTarget -destination $script:DIST_DIR
 }
 
 function buildApp() {
@@ -319,4 +420,6 @@ try {
     set-location $script:SRC_DIR
     $env:PKG_VERSION=""
     $env:VERSION=""
+    $env:VERSION_SEMVER=""
+    $env:VERSION_METADATA=""
 }

--- a/scripts/env.sh
+++ b/scripts/env.sh
@@ -1,6 +1,76 @@
 # Common environment setup across build*.sh scripts
 
-export VERSION=${VERSION:-$(git describe --tags --first-parent --abbrev=7 --long --dirty --always | sed -e "s/^v//g")}
+# Derive version metadata from Cargo and Git so that Rust builds embed
+# consistent release information. This function populates VERSION, VERSION_SEMVER,
+# and VERSION_METADATA if they are not already provided by the caller.
+derive_version_metadata() {
+    # Determine the Cargo package that produces the primary binary.
+    cargo_package=${CARGO_PACKAGE_NAME:-"oxi-llama"}
+
+    cargo_version=""
+    if command -v cargo >/dev/null 2>&1; then
+        cargo_version=$(cargo pkgid -p "$cargo_package" 2>/dev/null | awk -F'#' 'NF > 1 { print $2 }')
+    fi
+
+    git_describe=""
+    if command -v git >/dev/null 2>&1 && git rev-parse --git-dir >/dev/null 2>&1; then
+        git_describe=$(git describe --tags --first-parent --abbrev=7 --long --dirty --always 2>/dev/null | sed -e 's/^v//g')
+    fi
+
+    metadata=""
+    if [ -n "$cargo_version" ] && [ -n "$git_describe" ]; then
+        case "$git_describe" in
+            ${cargo_version}-*)
+                metadata=${git_describe#${cargo_version}-}
+                metadata=$(printf '%s' "$metadata" | sed 's/-/./g')
+                ;;
+            *)
+                metadata=$(printf '%s' "$git_describe" | sed 's/-/./g')
+                ;;
+        esac
+    elif [ -n "$git_describe" ]; then
+        metadata=$(printf '%s' "$git_describe" | sed 's/-/./g')
+    fi
+
+    if [ -z "${VERSION:-}" ]; then
+        if [ -n "$cargo_version" ]; then
+            if [ -n "$metadata" ]; then
+                VERSION="${cargo_version}+${metadata}"
+            else
+                VERSION="$cargo_version"
+            fi
+        elif [ -n "$git_describe" ]; then
+            VERSION="$git_describe"
+        else
+            VERSION="0.0.0"
+        fi
+    fi
+
+    if [ -z "${VERSION_SEMVER:-}" ]; then
+        if [ -n "$cargo_version" ]; then
+            VERSION_SEMVER="$cargo_version"
+        else
+            VERSION_SEMVER="${VERSION%%+*}"
+        fi
+    fi
+
+    if [ -z "${VERSION_METADATA:-}" ]; then
+        if [ -n "$metadata" ]; then
+            VERSION_METADATA="$metadata"
+        elif [ -n "$git_describe" ]; then
+            VERSION_METADATA=$(printf '%s' "$git_describe" | sed 's/-/./g')
+        else
+            VERSION_METADATA="${VERSION}"
+        fi
+    fi
+
+    export VERSION VERSION_SEMVER VERSION_METADATA
+
+    unset cargo_package cargo_version git_describe metadata
+}
+
+derive_version_metadata
+
 # TODO - consider `docker buildx ls --format=json` to autodiscover platform capability
 PLATFORM=${PLATFORM:-"linux/arm64,linux/amd64"}
 DOCKER_ORG=${DOCKER_ORG:-"ollama"}
@@ -9,12 +79,17 @@ CARGO_FEATURES=${CARGO_FEATURES:-""}
 RUST_TARGETS=${RUST_TARGETS:-""}
 OLLAMA_COMMON_BUILD_ARGS="--build-arg=VERSION --build-arg=CARGO_FEATURES=${CARGO_FEATURES} --build-arg=RUST_TARGETS=${RUST_TARGETS}"
 
-echo "Building Ollama"
-echo "VERSION=$VERSION"
-echo "PLATFORM=$PLATFORM"
-if [ -n "$CARGO_FEATURES" ]; then
-    echo "CARGO_FEATURES=$CARGO_FEATURES"
-fi
-if [ -n "$RUST_TARGETS" ]; then
-    echo "RUST_TARGETS=$RUST_TARGETS"
+if [ -z "${OLLAMA_ENV_QUIET:-}" ]; then
+    echo "Building Ollama"
+    echo "VERSION=$VERSION"
+    echo "PLATFORM=$PLATFORM"
+    if [ -n "$CARGO_FEATURES" ]; then
+        echo "CARGO_FEATURES=$CARGO_FEATURES"
+    fi
+    if [ -n "$RUST_TARGETS" ]; then
+        echo "RUST_TARGETS=$RUST_TARGETS"
+    fi
+    if [ -n "$VERSION_METADATA" ] && [ "$VERSION_METADATA" != "$VERSION" ]; then
+        echo "VERSION_METADATA=$VERSION_METADATA"
+    fi
 fi


### PR DESCRIPTION
## Summary
- derive shared Cargo/Git version metadata in `scripts/env.sh` and expose quiet-mode sourcing for other build scripts
- update the macOS build to reuse the shared metadata, honor optional cargo features, and package any runtime dylibs alongside the universal app archive
- refresh the Windows build pipeline to emit Rust-aware version strings, pass optional cargo features, bundle runtime DLLs, and clean up exported environment variables

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_b_68cc256fd844832f84129238f1b84666