### PR TITLE
Update CI workflows for Rust toolchain

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,6 @@ on:
     tags:
       - 'v*'
 
-env:
-  CGO_CFLAGS: '-O3'
-  CGO_CXXFLAGS: '-O3'
-
 jobs:
   setup-environment:
     runs-on: ubuntu-latest
@@ -233,19 +229,43 @@ jobs:
           - os: linux
             arch: amd64
             target: archive
+            rust-target: x86_64-unknown-linux-gnu
           - os: linux
             arch: amd64
             target: rocm
+            rust-target: x86_64-unknown-linux-gnu
           - os: linux
             arch: arm64
             target: archive
-    runs-on: ${{ matrix.arch == 'arm64' && format('{0}-{1}', matrix.os, matrix.arch) || matrix.os }}
+            rust-target: aarch64-unknown-linux-gnu
+    runs-on: ubuntu-latest
     environment: release
     needs: setup-environment
     env:
       VERSION: ${{ needs.setup-environment.outputs.VERSION }}
     steps:
       - uses: actions/checkout@v4
+      - name: install rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.rust-target }}
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          if [ '${{ matrix.arch }}' = 'arm64' ]; then
+            sudo apt-get install -y gcc-aarch64-linux-gnu pigz
+          else
+            sudo apt-get install -y pigz
+          fi
+        shell: bash
+      - uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+      - name: cargo build (release)
+        run: |
+          cargo build --release --bin ollama --target ${{ matrix.rust-target }}
+          echo "RUST_BINARY=target/${{ matrix.rust-target }}/release/ollama" >> "$GITHUB_ENV"
+        shell: bash
       - uses: docker/setup-buildx-action@v3
       - uses: docker/build-push-action@v6
         with:
@@ -255,8 +275,12 @@ jobs:
           build-args: |
             VERSION=${{ env.VERSION }}
           outputs: type=local,dest=dist/${{ matrix.os }}-${{ matrix.arch }}
-          cache-from: type=registry,ref=${{ vars.DOCKER_REPO }}:latest
-          cache-to: type=inline
+          cache-from: type=gha,scope=linux-${{ matrix.arch }}-${{ matrix.target }}
+          cache-to: type=gha,scope=linux-${{ matrix.arch }}-${{ matrix.target }},mode=max
+      - name: Inject Rust binary into artifact
+        run: |
+          install -Dm755 "$RUST_BINARY" "dist/${{ matrix.os }}-${{ matrix.arch }}/bin/ollama"
+        shell: bash
       - run: |
           for COMPONENT in bin/* lib/ollama/*; do
             case "$COMPONENT" in
@@ -277,7 +301,8 @@ jobs:
           done
       - run: |
           for ARCHIVE in dist/${{ matrix.os }}-${{ matrix.arch }}/*.tar.in; do
-            tar c -C dist/${{ matrix.os }}-${{ matrix.arch }} -T $ARCHIVE --owner 0 --group 0 | pigz -9vc >$(basename ${ARCHIVE//.*/}.tgz);
+            out=$(basename "$ARCHIVE" .tar.in)
+            tar c -C dist/${{ matrix.os }}-${{ matrix.arch }} -T "$ARCHIVE" --owner 0 --group 0 | pigz -9vc >"${out}.tgz"
           done
       - uses: actions/upload-artifact@v4
         with:
@@ -303,9 +328,11 @@ jobs:
             suffix: '-rocm'
             build-args: |
               FLAVOR=rocm
-    runs-on: ${{ matrix.arch == 'arm64' && format('{0}-{1}', matrix.os, matrix.arch) || matrix.os }}
+    runs-on: ubuntu-latest
     environment: release
-    needs: setup-environment
+    needs:
+      - setup-environment
+      - linux-build
     env:
       VERSION: ${{ needs.setup-environment.outputs.VERSION }}
     steps:
@@ -324,8 +351,8 @@ jobs:
             VERSION=${{ env.VERSION }}
             ${{ matrix.build-args }}
           outputs: type=image,name=${{ vars.DOCKER_REPO }},push-by-digest=true,name-canonical=true,push=true
-          cache-from: type=registry,ref=${{ vars.DOCKER_REPO }}:latest
-          cache-to: type=inline
+          cache-from: type=gha,scope=docker-${{ matrix.arch }}${{ matrix.suffix }}
+          cache-to: type=gha,scope=docker-${{ matrix.arch }}${{ matrix.suffix }},mode=max
       - run: |
           mkdir -p ${{ matrix.os }}-${{ matrix.arch }}
           echo "${{ steps.build-push.outputs.digest }}" >${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.suffix }}.txt

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -7,7 +7,7 @@ concurrency:
   # For non-PR pushes, concurrency.group needs to be unique for every distinct
   # CI run we want to have happen. Use run_id, which in practice means all
   # non-PR CI runs will be allowed to run without preempting each other.
-  group: ${{ github.workflow }}-$${{ github.pull_request.number || github.run_id }}
+  group: '${{ github.workflow }}-${{ github.pull_request.number || github.run_id }}'
   cancel-in-progress: true
 
 on:
@@ -18,146 +18,8 @@ on:
       - '!README.md'
 
 jobs:
-  changes:
+  lint:
     runs-on: ubuntu-latest
-    outputs:
-      changed: ${{ steps.changes.outputs.changed }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - id: changes
-        run: |
-          changed() {
-            local BASE=${{ github.event.pull_request.base.sha }}
-            local HEAD=${{ github.event.pull_request.head.sha }}
-            local MERGE_BASE=$(git merge-base $BASE $HEAD)
-            git diff-tree -r --no-commit-id --name-only "$MERGE_BASE" "$HEAD" \
-              | xargs python3 -c "import sys; from pathlib import Path; print(any(Path(x).match(glob) for x in sys.argv[1:] for glob in '$*'.split(' ')))"
-          }
-
-          echo changed=$(changed 'llama/llama.cpp/**/*' 'ml/backend/ggml/ggml/**/*') | tee -a $GITHUB_OUTPUT
-
-  linux:
-    needs: [changes]
-    if: needs.changes.outputs.changed == 'True'
-    strategy:
-      matrix:
-        include:
-          - preset: CPU
-          - preset: CUDA
-            container: nvidia/cuda:13.0.0-devel-ubuntu22.04
-            flags: '-DCMAKE_CUDA_ARCHITECTURES=87'
-          - preset: ROCm
-            container: rocm/dev-ubuntu-22.04:6.1.2
-            extra-packages: rocm-libs
-            flags: '-DAMDGPU_TARGETS=gfx1010 -DCMAKE_PREFIX_PATH=/opt/rocm'
-    runs-on: linux
-    container: ${{ matrix.container }}
-    steps:
-      - uses: actions/checkout@v4
-      - run: |
-          [ -n "${{ matrix.container }}" ] || sudo=sudo
-          $sudo apt-get update
-          $sudo apt-get install -y cmake ccache ${{ matrix.extra-packages }}
-        env:
-          DEBIAN_FRONTEND: noninteractive
-      - uses: actions/cache@v4
-        with:
-          path: /github/home/.cache/ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}
-      - run: |
-          cmake --preset ${{ matrix.preset }} ${{ matrix.flags }}
-          cmake --build --preset ${{ matrix.preset }} --parallel
-
-  windows:
-    needs: [changes]
-    if: needs.changes.outputs.changed == 'True'
-    strategy:
-      matrix:
-        include:
-          - preset: CPU
-          - preset: CUDA
-            install: https://developer.download.nvidia.com/compute/cuda/13.0.0/local_installers/cuda_13.0.0_windows.exe
-            flags: '-DCMAKE_CUDA_ARCHITECTURES=80'
-            cuda-components:
-              - '"cudart"'
-              - '"nvcc"'
-              - '"cublas"'
-              - '"cublas_dev"'
-              - '"crt"'
-              - '"nvvm"'
-              - '"nvptxcompiler"'
-            cuda-version: '13.0'
-          - preset: ROCm
-            install: https://download.amd.com/developer/eula/rocm-hub/AMD-Software-PRO-Edition-24.Q4-WinSvr2022-For-HIP.exe
-            flags: '-DAMDGPU_TARGETS=gfx1010 -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_C_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma" -DCMAKE_CXX_FLAGS="-parallel-jobs=4 -Wno-ignored-attributes -Wno-deprecated-pragma"'
-    runs-on: windows
-    steps:
-      - run: |
-          choco install -y --no-progress ccache ninja
-          ccache -o cache_dir=${{ github.workspace }}\.ccache
-      - if: matrix.preset == 'CUDA' || matrix.preset == 'ROCm'
-        id: cache-install
-        uses: actions/cache/restore@v4
-        with:
-          path: |
-            C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA
-            C:\Program Files\AMD\ROCm
-          key: ${{ matrix.install }}
-      - if: matrix.preset == 'CUDA'
-        name: Install CUDA ${{ matrix.cuda-version }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          if ("${{ steps.cache-install.outputs.cache-hit }}" -ne 'true') {
-            Invoke-WebRequest -Uri "${{ matrix.install }}" -OutFile "install.exe"
-            $subpackages = @(${{ join(matrix.cuda-components, ', ') }}) | Foreach-Object {"${_}_${{ matrix.cuda-version }}"}
-            Start-Process -FilePath .\install.exe -ArgumentList (@("-s") + $subpackages) -NoNewWindow -Wait
-          }
-
-          $cudaPath = (Resolve-Path "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\*").path
-          echo "$cudaPath\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-      - if: matrix.preset == 'ROCm'
-        name: Install ROCm ${{ matrix.rocm-version }}
-        run: |
-          $ErrorActionPreference = "Stop"
-          if ("${{ steps.cache-install.outputs.cache-hit }}" -ne 'true') {
-            Invoke-WebRequest -Uri "${{ matrix.install }}" -OutFile "install.exe"
-            Start-Process -FilePath .\install.exe -ArgumentList '-install' -NoNewWindow -Wait
-          }
-
-          $hipPath = (Resolve-Path "C:\Program Files\AMD\ROCm\*").path
-          echo "$hipPath\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
-          echo "CC=$hipPath\bin\clang.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "CXX=$hipPath\bin\clang++.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "HIPCXX=$hipPath\bin\clang++.exe" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "HIP_PLATFORM=amd" | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "CMAKE_PREFIX_PATH=$hipPath" | Out-File -FilePath $env:GITHUB_ENV -Append
-      - if: ${{ !cancelled() && steps.cache-install.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA
-            C:\Program Files\AMD\ROCm
-          key: ${{ matrix.install }}
-      - uses: actions/checkout@v4
-      - uses: actions/cache@v4
-        with:
-          path: ${{ github.workspace }}\.ccache
-          key: ccache-${{ runner.os }}-${{ runner.arch }}-${{ matrix.preset }}
-      - run: |
-          Import-Module 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\Microsoft.VisualStudio.DevShell.dll'
-          Enter-VsDevShell -VsInstallPath 'C:\Program Files\Microsoft Visual Studio\2022\Enterprise' -SkipAutomaticLocation  -DevCmdArguments '-arch=x64 -no_logo'
-          cmake --preset "${{ matrix.preset }}" ${{ matrix.flags }}
-          cmake --build --parallel --preset "${{ matrix.preset }}"
-        env:
-          CMAKE_GENERATOR: Ninja
-
-  test:
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
     steps:
       - name: checkout
         uses: actions/checkout@v4
@@ -167,25 +29,48 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      - name: cache cargo
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
+      - uses: Swatinem/rust-cache@v2
 
       - name: cargo fmt
         run: cargo fmt --all --check
 
       - name: cargo clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
 
-      - name: cargo test
-        run: cargo test --workspace --all-features
+  test:
+    strategy:
+      matrix:
+        include:
+          - os: ubuntu-latest
+            feature-set: cpu
+            args: ""
+          - os: ubuntu-latest
+            feature-set: gpu
+            args: "--features tch"
+          - os: macos-latest
+            feature-set: cpu
+            args: ""
+          - os: windows-latest
+            feature-set: cpu
+            args: ""
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: checkout
+        uses: actions/checkout@v4
+
+      - name: install toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: cargo test (${{ matrix.feature-set }})
+        run: |
+          if [ -z "${{ matrix.args }}" ]; then
+            cargo test --workspace --locked
+          else
+            cargo test --workspace --locked ${{ matrix.args }}
+          fi
+        shell: bash
 
   patches:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- simplify the pull request test workflow to run rustfmt, clippy, and a CPU/GPU cargo test matrix via the stable toolchain
- teach the Linux release job to build Rust binaries directly, reuse them in the packaged artifacts, and switch to BuildKit caches keyed per target
- require Docker image builds to depend on the Rust release outputs and update their caching strategy accordingly

## Testing
- not run (workflow-only change)


------
https://chatgpt.com/codex/tasks/task_b_68cd96f11cc4832facdefbc37fe4927a