### PR TITLE
Update Linux installers for new Rust bundle naming

### DIFF
--- a/docs/distribution.md
+++ b/docs/distribution.md
@@ -1,0 +1,46 @@
+# Linux Distribution Bundles
+
+The Rust-based release pipeline emits architecture-specific tarballs that share a common
+layout. All archives are compressed as `tar.gz` files and extract directly into the target
+prefix (typically `/usr`).
+
+## Artifact naming
+
+| Artifact | Purpose | Contents |
+| --- | --- | --- |
+| `ollama-linux-amd64.tar.gz` | Primary runtime for x86_64 hosts | Installs the Rust `ollama` CLI into `/usr/bin` and CPU/CUDA runtime libraries into `/usr/lib/ollama`. |
+| `ollama-linux-arm64.tar.gz` | Primary runtime for ARM64 hosts | Same layout as the amd64 bundle, built for `aarch64`. |
+| `ollama-linux-amd64-gpu-rocm.tar.gz` | Optional AMD GPU support for x86_64 | Adds ROCm libraries under `/usr/lib/ollama/rocm`; unpack alongside the base bundle. |
+| `ollama-linux-arm64-gpu-jetpack5.tar.gz` | JetPack 5 CUDA runtime | Provides `/usr/lib/ollama/cuda_jetpack5` for NVIDIA Jetson devices running JetPack 5. |
+| `ollama-linux-arm64-gpu-jetpack6.tar.gz` | JetPack 6 CUDA runtime | Provides `/usr/lib/ollama/cuda_jetpack6` for JetPack 6 systems. |
+
+> ℹ️ Legacy `.tgz` filenames remain available for older releases. The installer will fall back
+to those names when fetching historic versions via `OLLAMA_VERSION`.
+
+## Directory structure
+
+Each archive maintains the following layout relative to the installation prefix:
+
+```
+/usr/
+  bin/
+    ollama
+  lib/
+    ollama/
+      <runtime libraries>
+```
+
+The base bundle includes the Rust binary and supporting shared libraries in `lib/ollama`.
+GPU-specific bundles only contain their respective subdirectories (for example,
+`lib/ollama/rocm` or `lib/ollama/cuda_jetpack6`).
+
+## Testing downloads locally
+
+Set `OLLAMA_DOWNLOAD_BASE_URL` to a custom `file://` or HTTP endpoint to make the
+installer consume alternate artifacts:
+
+```bash
+OLLAMA_DOWNLOAD_BASE_URL="file:///tmp/ollama-dist" ./scripts/install.sh
+```
+
+This is useful when smoke-testing new bundles without publishing them to the public CDN.

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -16,10 +16,16 @@ curl -fsSL https://ollama.com/install.sh | sh
 Download and extract the package:
 
 ```shell
-curl -LO https://ollama.com/download/ollama-linux-amd64.tgz
+curl -LO https://ollama.com/download/ollama-linux-amd64.tar.gz
 sudo rm -rf /usr/lib/ollama
-sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+sudo tar -C /usr -xzf ollama-linux-amd64.tar.gz
 ```
+
+The Rust release process publishes separate tarballs for architecture-specific components:
+
+- `ollama-linux-<arch>.tar.gz` – installs the Rust CLI along with CPU and CUDA runtime libraries into `/usr/bin` and `/usr/lib/ollama`.
+- `ollama-linux-<arch>-gpu-rocm.tar.gz` – provides the optional ROCm GPU runtime for AMD hardware; extract alongside the base bundle when required.
+- `ollama-linux-arm64-gpu-jetpack{5,6}.tar.gz` – augment ARM64 systems running NVIDIA JetPack with the appropriate GPU runtimes.
 
 Start Ollama:
 
@@ -38,12 +44,12 @@ ollama -v
 If you have an AMD GPU, **also** download and extract the additional ROCm package:
 
 > [!IMPORTANT]
-> The ROCm tgz contains only AMD dependent libraries.  You must extract **both** `ollama-linux-amd64.tgz` and `ollama-linux-amd64-rocm.tgz` into the same location.
+> The ROCm bundle contains only AMD dependent libraries.  You must extract **both** `ollama-linux-amd64.tar.gz` and `ollama-linux-amd64-gpu-rocm.tar.gz` into the same location.
 
 
 ```shell
-curl -L https://ollama.com/download/ollama-linux-amd64-rocm.tgz -o ollama-linux-amd64-rocm.tgz
-sudo tar -C /usr -xzf ollama-linux-amd64-rocm.tgz
+curl -L https://ollama.com/download/ollama-linux-amd64-gpu-rocm.tar.gz -o ollama-linux-amd64-gpu-rocm.tar.gz
+sudo tar -C /usr -xzf ollama-linux-amd64-gpu-rocm.tar.gz
 ```
 
 ### ARM64 install
@@ -51,8 +57,8 @@ sudo tar -C /usr -xzf ollama-linux-amd64-rocm.tgz
 Download and extract the ARM64-specific package:
 
 ```shell
-curl -L https://ollama.com/download/ollama-linux-arm64.tgz -o ollama-linux-arm64.tgz
-sudo tar -C /usr -xzf ollama-linux-arm64.tgz
+curl -L https://ollama.com/download/ollama-linux-arm64.tar.gz -o ollama-linux-arm64.tar.gz
+sudo tar -C /usr -xzf ollama-linux-arm64.tar.gz
 ```
 
 ### Adding Ollama as a startup service (recommended)
@@ -146,8 +152,8 @@ curl -fsSL https://ollama.com/install.sh | sh
 Or by re-downloading Ollama:
 
 ```shell
-curl -L https://ollama.com/download/ollama-linux-amd64.tgz -o ollama-linux-amd64.tgz
-sudo tar -C /usr -xzf ollama-linux-amd64.tgz
+curl -L https://ollama.com/download/ollama-linux-amd64.tar.gz -o ollama-linux-amd64.tar.gz
+sudo tar -C /usr -xzf ollama-linux-amd64.tar.gz
 ```
 
 ## Installing specific versions

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -38,18 +38,50 @@ if echo $PLATFORM | grep "amd64" > /dev/null; then
 fi
 
 # buildx behavior changes for single vs. multiplatform
+
+compress_bundle() {
+    src_dir="$1"
+    shift
+    output="$1"
+    shift
+    tar c -C "$src_dir" "$@" | pigz -9vc >"$output"
+}
+
+create_archives_for_arch() {
+    root="$1"
+    arch="$2"
+
+    echo "Creating bundle archives for linux/${arch} from ${root}"
+
+    base_archive="./dist/ollama-linux-${arch}.tar.gz"
+    compress_bundle "$root" "$base_archive" \
+        --exclude "lib/ollama/cuda_jetpack5" \
+        --exclude "lib/ollama/cuda_jetpack6" \
+        --exclude "lib/ollama/rocm" \
+        bin lib
+
+    if [ -d "$root/lib/ollama/cuda_jetpack5" ]; then
+        compress_bundle "$root" "./dist/ollama-linux-${arch}-gpu-jetpack5.tar.gz" \
+            lib/ollama/cuda_jetpack5
+    fi
+
+    if [ -d "$root/lib/ollama/cuda_jetpack6" ]; then
+        compress_bundle "$root" "./dist/ollama-linux-${arch}-gpu-jetpack6.tar.gz" \
+            lib/ollama/cuda_jetpack6
+    fi
+
+    if [ -d "$root/lib/ollama/rocm" ]; then
+        compress_bundle "$root" "./dist/ollama-linux-${arch}-gpu-rocm.tar.gz" \
+            lib/ollama/rocm
+    fi
+}
+
 echo "Compressing linux tar bundles..."
 if echo $PLATFORM | grep "," > /dev/null ; then
-        tar c -C ./dist/linux_arm64 --exclude cuda_jetpack5 --exclude cuda_jetpack6 . | pigz -9vc >./dist/ollama-linux-arm64.tgz
-        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack5  | pigz -9vc >./dist/ollama-linux-arm64-jetpack5.tgz
-        tar c -C ./dist/linux_arm64 ./lib/ollama/cuda_jetpack6  | pigz -9vc >./dist/ollama-linux-arm64-jetpack6.tgz
-        tar c -C ./dist/linux_amd64 --exclude rocm . | pigz -9vc >./dist/ollama-linux-amd64.tgz
-        tar c -C ./dist/linux_amd64 ./lib/ollama/rocm  | pigz -9vc >./dist/ollama-linux-amd64-rocm.tgz
+    create_archives_for_arch "./dist/linux_arm64" "arm64"
+    create_archives_for_arch "./dist/linux_amd64" "amd64"
 elif echo $PLATFORM | grep "arm64" > /dev/null ; then
-        tar c -C ./dist/ --exclude cuda_jetpack5 --exclude cuda_jetpack6 bin lib | pigz -9vc >./dist/ollama-linux-arm64.tgz
-        tar c -C ./dist/ ./lib/ollama/cuda_jetpack5  | pigz -9vc >./dist/ollama-linux-arm64-jetpack5.tgz
-        tar c -C ./dist/ ./lib/ollama/cuda_jetpack6  | pigz -9vc >./dist/ollama-linux-arm64-jetpack6.tgz
+    create_archives_for_arch "./dist" "arm64"
 elif echo $PLATFORM | grep "amd64" > /dev/null ; then
-        tar c -C ./dist/ --exclude rocm bin lib | pigz -9vc >./dist/ollama-linux-amd64.tgz
-        tar c -C ./dist/ ./lib/ollama/rocm  | pigz -9vc >./dist/ollama-linux-amd64-rocm.tgz
+    create_archives_for_arch "./dist" "amd64"
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -46,6 +46,29 @@ case "$KERN" in
 esac
 
 VER_PARAM="${OLLAMA_VERSION:+?version=$OLLAMA_VERSION}"
+DOWNLOAD_BASE_URL=${OLLAMA_DOWNLOAD_BASE_URL:-"https://ollama.com/download"}
+
+download_bundle() {
+    dest="$1"
+    shift
+
+    for artifact in "$@"; do
+        [ -n "$artifact" ] || continue
+        url="${DOWNLOAD_BASE_URL%/}/$artifact${VER_PARAM}"
+        filename=$(basename "$artifact")
+        tmp="$TEMP_DIR/$filename"
+        status "Fetching ${filename}"
+        if curl --fail --show-error --location --progress-bar "$url" -o "$tmp"; then
+            $SUDO tar -xzf "$tmp" -C "$dest"
+            rm -f "$tmp"
+            return 0
+        fi
+        warning "Download failed for $artifact"
+        rm -f "$tmp"
+    done
+
+    return 1
+}
 
 SUDO=
 if [ "$(id -u)" -ne 0 ]; then
@@ -78,10 +101,12 @@ fi
 status "Installing ollama to $OLLAMA_INSTALL_DIR"
 $SUDO install -o0 -g0 -m755 -d $BINDIR
 $SUDO install -o0 -g0 -m755 -d "$OLLAMA_INSTALL_DIR/lib/ollama"
-status "Downloading Linux ${ARCH} bundle"
-curl --fail --show-error --location --progress-bar \
-    "https://ollama.com/download/ollama-linux-${ARCH}.tgz${VER_PARAM}" | \
-    $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+status "Downloading Linux ${ARCH} runtime bundle"
+if ! download_bundle "$OLLAMA_INSTALL_DIR" \
+    "ollama-linux-${ARCH}.tar.gz" \
+    "ollama-linux-${ARCH}.tgz"; then
+    error "Unable to download Linux ${ARCH} bundle"
+fi
 
 if [ "$OLLAMA_INSTALL_DIR/bin/ollama" != "$BINDIR/ollama" ] ; then
     status "Making ollama accessible in the PATH in $BINDIR"
@@ -92,14 +117,18 @@ fi
 if [ -f /etc/nv_tegra_release ] ; then
     if grep R36 /etc/nv_tegra_release > /dev/null ; then
         status "Downloading JetPack 6 components"
-        curl --fail --show-error --location --progress-bar \
-            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack6.tgz${VER_PARAM}" | \
-            $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+        if ! download_bundle "$OLLAMA_INSTALL_DIR" \
+            "ollama-linux-${ARCH}-gpu-jetpack6.tar.gz" \
+            "ollama-linux-${ARCH}-jetpack6.tgz"; then
+            error "Unable to download JetPack 6 bundle"
+        fi
     elif grep R35 /etc/nv_tegra_release > /dev/null ; then
         status "Downloading JetPack 5 components"
-        curl --fail --show-error --location --progress-bar \
-            "https://ollama.com/download/ollama-linux-${ARCH}-jetpack5.tgz${VER_PARAM}" | \
-            $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+        if ! download_bundle "$OLLAMA_INSTALL_DIR" \
+            "ollama-linux-${ARCH}-gpu-jetpack5.tar.gz" \
+            "ollama-linux-${ARCH}-jetpack5.tgz"; then
+            error "Unable to download JetPack 5 bundle"
+        fi
     else
         warning "Unsupported JetPack version detected.  GPU may not be supported"
     fi
@@ -223,9 +252,11 @@ fi
 
 if check_gpu lspci amdgpu || check_gpu lshw amdgpu; then
     status "Downloading Linux ROCm ${ARCH} bundle"
-    curl --fail --show-error --location --progress-bar \
-        "https://ollama.com/download/ollama-linux-${ARCH}-rocm.tgz${VER_PARAM}" | \
-        $SUDO tar -xzf - -C "$OLLAMA_INSTALL_DIR"
+    if ! download_bundle "$OLLAMA_INSTALL_DIR" \
+        "ollama-linux-${ARCH}-gpu-rocm.tar.gz" \
+        "ollama-linux-${ARCH}-rocm.tgz"; then
+        error "Unable to download ROCm bundle"
+    fi
 
     install_success
     status "AMD GPU ready."


### PR DESCRIPTION
## Summary
- document the new Rust release bundle naming and layout for Linux
- adjust the Linux build pipeline to emit `.tar.gz` archives with GPU-specific bundle names
- teach the installer and Linux docs to consume the new artifacts while retaining fallback support

## Testing
- sh -n scripts/install.sh
- sh -n scripts/build_linux.sh
- OLLAMA_DOWNLOAD_BASE_URL="file:///tmp/ollama-artifacts" sh scripts/install.sh
- /usr/local/bin/ollama --version

------
https://chatgpt.com/codex/tasks/task_b_68ce967f8e64832f877819f18c0327c1