### PR TITLE
docs: update rust-first documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,9 +53,10 @@ The title should look like:
 
     <package>: <short description>
 
-The package is the most affected Go package. If the change does not affect Go
-code, then use the directory name instead. Changes to a single well-known
-file in the root directory may use the file name.
+The package is the most affected Rust crate or workspace member. If the change
+is limited to documentation or auxiliary files, use the directory name instead.
+Changes to a single well-known file in the root directory may use the file
+name.
 
 The short description should start with a lowercase letter and be a
 continuation of the sentence:
@@ -76,13 +77,21 @@ Bad Examples:
 
 **Tests**
 
-Please include tests. Strive to test behavior, not implementation.
+Please include tests. Strive to test behavior, not implementation. Pull
+requests that modify Rust code should run the standard checks locally before
+submission:
+
+```shell
+cargo test --all
+cargo fmt --all --check
+cargo clippy --all-targets --all-features -- -D warnings
+```
 
 **New dependencies**
 
-Dependencies should be added sparingly. If you are adding a new dependency,
-please explain why it is necessary and what other ways you attempted that
-did not work without it.
+Dependencies should be added sparingly. If you are adding a new crate or
+binary dependency, please explain why it is necessary and what other ways you
+attempted that did not work without it.
 
 ## Need help?
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ ollama stop llama3.2
 
 `ollama serve` is used when you want to start ollama without running the desktop application.
 
+## Architecture and technology
+
+The Ollama daemon, CLI, and supporting libraries are implemented in Rust and
+shipped from the workspace defined in `Cargo.toml`. Each subsystem (server,
+runner, model loading, templating, etc.) lives in a dedicated crate under the
+`rust/` directory and is built together through Cargo. A handful of
+platform-native projects remain by design:
+
+- `macapp/` contains the Electron desktop application that consumes the Rust
+  APIs.
+- `installer/setup.iss` and the scripts in `installer/` and `scripts/` provide
+  Windows and POSIX packaging glue around the Rust binaries.
+
+See [docs/rust-migration.md](./docs/rust-migration.md) for a historical view of
+the Go-to-Rust migration and the current component inventory.
+
 ## Building
 
 See the [developer guide](https://github.com/ollama/ollama/blob/main/docs/development.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 Install prerequisites:
 
-- [Rust toolchain](https://rustup.rs/)
+- [Rust toolchain](https://rustup.rs/) (see [Rust setup](#rust-setup) for detailed steps)
 - C/C++ Compiler e.g. Clang on macOS, [TDM-GCC](https://github.com/jmeubank/tdm-gcc/releases/latest) (Windows amd64) or [llvm-mingw](https://github.com/mstorsjo/llvm-mingw) (Windows arm64), GCC/Clang on Linux.
 
 Then build and run Ollama from the root directory of the repository:
@@ -10,6 +10,58 @@ Then build and run Ollama from the root directory of the repository:
 ```shell
 cargo run -- serve
 ```
+
+## Rust setup
+
+Ollama's server and command-line interface are implemented entirely in Rust. The
+repository is a Cargo workspace containing the binary target in `src/` and the
+supporting crates under `rust/`.
+
+1. Install `rustup` from [rustup.rs](https://rustup.rs) and select the `stable`
+   toolchain (the project tests against the latest stable release).
+2. Install the components used by the CI checks:
+
+   ```shell
+   rustup component add rustfmt clippy rust-analyzer
+   ```
+
+3. (Optional) Install additional targets when cross-compiling:
+
+   ```shell
+   rustup target add aarch64-apple-darwin x86_64-apple-darwin \
+     aarch64-pc-windows-msvc x86_64-pc-windows-msvc
+   ```
+
+4. Confirm the toolchain is available:
+
+   ```shell
+   cargo --version
+   ```
+
+### Common Cargo commands
+
+- `cargo run -- serve` – start the Ollama daemon directly from the workspace.
+- `cargo build --release` – compile optimized binaries for packaging.
+- `cargo test --all` – execute the workspace test suite.
+- `cargo fmt --all --check` – ensure formatting matches `rustfmt`.
+- `cargo clippy --all-targets --all-features -- -D warnings` – lint the code.
+
+### GPU features
+
+GPU acceleration is controlled through Cargo features exposed by the `ml`
+crate:
+
+- Enable the Torch runtime with `ml/tch`.
+- Select a backend with `tch/cuda` (NVIDIA) or `tch/rocm` (AMD).
+
+You can combine these features when building locally:
+
+```shell
+cargo build --release --features ml/tch,tch/cuda
+```
+
+When building in Docker, pass `CARGO_FEATURES=ml/tch,tch/<backend>` as shown in
+the [Docker section](#docker).
 
 ## macOS (Apple Silicon)
 

--- a/docs/linux.md
+++ b/docs/linux.md
@@ -8,6 +8,11 @@ To install Ollama, run the following command:
 curl -fsSL https://ollama.com/install.sh | sh
 ```
 
+> [!NOTE]
+> The Linux installer downloads the Rust-based Ollama daemon and CLI that are
+> built from the workspace in this repository. Shell scripts included in the
+> bundle only configure the system service wrappers.
+
 ## Manual install
 
 > [!NOTE]

--- a/docs/modelfile.md
+++ b/docs/modelfile.md
@@ -163,7 +163,7 @@ PARAMETER <parameter> <parametervalue>
 
 ### TEMPLATE
 
-`TEMPLATE` of the full prompt template to be passed into the model. It may include (optionally) a system message, a user's message and the response from the model. Note: syntax may be model specific. Templates use Go [template syntax](https://pkg.go.dev/text/template).
+`TEMPLATE` of the full prompt template to be passed into the model. It may include (optionally) a system message, a user's message and the response from the model. Note: syntax may be model specific. Templates use Go-style [template syntax](https://pkg.go.dev/text/template), implemented in Rust for runtime compatibility.
 
 #### Template Variables
 

--- a/docs/rust-migration.md
+++ b/docs/rust-migration.md
@@ -1,19 +1,35 @@
 # Rust Migration Inventory
 
-This document tracks components that previously relied on Go or other tooling and the status of their Rust replacements.
+The Go implementation of the Ollama daemon has been fully retired. All runtime
+services, the CLI, and supporting libraries now live in the Rust workspace
+rooted at `Cargo.toml` and `rust/`. This page captures the historical
+translation of key components and the limited set of projects that intentionally
+remain in other languages.
 
-| Component | Previous Implementation | Decision | Replacement |
-|-----------|-------------------------|----------|-------------|
-| `fs/util/bufioutil` | Go helper wrapping `bufio.Reader` for seekable readers | Rewritten in Rust | `rust/fs/src/util/bufioutil.rs` (exposed via `fs::util::bufioutil::BufferedSeeker`) |
-| `template` package | Go prompt templating with embedded assets | Rewritten in Rust | `rust/template` crate embedding `template/` assets and providing `Template`, `Values`, and `named` helpers |
-| `installer/setup.iss` | Inno Setup script | Remains platform-native tooling | Windows packaging continues to rely on `installer/setup.iss`; integration with the Rust toolchain is tracked separately |
-| `macapp` Electron UI | Node/Electron project | Remains platform-native tooling | Documented as external dependency; Rust back-end exposes APIs consumed by the Electron front-end |
+## Completed migrations
 
-The new Rust crates are part of the `rust/` tree and can be built and tested independently:
+| Component | Previous Implementation | Replacement |
+|-----------|-------------------------|-------------|
+| Core server, runner, model, and CLI layers | Go modules spread across `./server`, `./runner`, `./model`, and friends | Workspace crates under `rust/server`, `rust/runner`, `rust/model`, `rust/cli`, and the binary entry point in `src/main.rs` |
+| Filesystem utilities such as `fs/util/bufioutil` | Go helper wrapping `bufio.Reader` for seekable readers | Rust translation in `rust/fs/src/util/bufioutil.rs` exposed via `fs::util::bufioutil::BufferedSeeker` |
+| Prompt templating | Go package embedding `template/` assets | Rust `template` crate embedding the assets and providing `Template`, `Values`, and named helpers |
+
+Each workspace crate can be built and tested individually, but all targets are
+also exercised from the repository root:
 
 ```bash
-cd rust/fs && cargo test
-cd rust/template && cargo test
+cargo test --all
 ```
 
-Future work will focus on wiring these crates into the top-level binaries and incrementally retiring the Go code paths once parity is validated in production.
+## Intentional non-Rust components
+
+The following projects continue to use platform-native tooling:
+
+| Component | Language / Tooling | Rationale |
+|-----------|--------------------|-----------|
+| `macapp/` | Electron/TypeScript | Provides the cross-platform desktop UI that consumes the Rust HTTP/gRPC APIs. |
+| `installer/setup.iss` | Inno Setup script | Windows packaging and shortcuts are authored in Inno Setup and invoked after the Rust binaries are produced. |
+| `scripts/` and `installer/` shell helpers | POSIX shell & PowerShell | Retained for packaging, release automation, and integration with OS-specific installers. |
+
+These components interface with the Rust binaries but do not contain runtime
+business logic.

--- a/docs/template.md
+++ b/docs/template.md
@@ -1,10 +1,13 @@
 # Template
 
-Ollama provides a powerful templating engine backed by Go's built-in templating engine to construct prompts for your large language model. This feature is a valuable tool to get the most out of your models.
+Ollama provides a powerful templating engine implemented in Rust while staying
+compatible with Go's templating syntax to construct prompts for your large
+language model. This feature is a valuable tool to get the most out of your
+models.
 
 ## Basic Template Structure
 
-A basic Go template consists of three main parts:
+A basic Go-style template consists of three main parts:
 
 * **Layout**: The overall structure of the template.
 * **Variables**: Placeholders for dynamic data that will be replaced with actual values when the template is rendered.
@@ -97,7 +100,7 @@ TEMPLATE """{{- if .System }}<|start_header_id|>system<|end_header_id|>
 
 ## Tips and Best Practices
 
-Keep the following tips and best practices in mind when working with Go templates:
+Keep the following tips and best practices in mind when working with Go-style templates:
 
 * **Be mindful of dot**: Control flow structures like `range` and `with` changes the value `.`
 * **Out-of-scope variables**: Use `$.` to reference variables not currently in scope, starting from the root


### PR DESCRIPTION
## Summary
- document the Rust toolchain requirements, cargo commands, and GPU features in the development guide
- refresh contributing and migration docs to reflect the completed Go-to-Rust transition and note the remaining non-Rust tooling
- align templating/modelfile docs and the README/Linux notes with the Rust implementation details

## Testing
- cargo fmt --all --check

------
https://chatgpt.com/codex/tasks/task_b_68ceec3e54dc832f910b2c2fe1d4cc05