### PR TITLE
Add NVML-based GPU detection on Linux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,8 +936,18 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b750cb3417fd1b327431a470f388520309479ab0bf5e323505daf0290cd3850"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.14.4",
+ "darling_macro 0.14.4",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
 ]
 
 [[package]]
@@ -955,14 +965,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4aab4dbc9f7611d8b55048a3a16d2d010c2c8334e46304b40ac1cc14bf3b48e"
 dependencies = [
- "darling_core",
+ "darling_core 0.14.4",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -999,7 +1034,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c11bdc11a0c47bc7d37d582b5285da6849c96681023680b906673c5707af7b0f"
 dependencies = [
- "darling",
+ "darling 0.14.4",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -1081,6 +1116,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
  "cfg-if",
+ "nvml-wrapper",
  "sysinfo",
 ]
 
@@ -2829,6 +2865,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "nvml-wrapper"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d5c6c0ef9702176a570f06ad94f3198bc29c524c8b498f1b9346e1b1bdcbb3a"
+dependencies = [
+ "bitflags 2.9.4",
+ "libloading 0.8.8",
+ "nvml-wrapper-sys",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "wrapcenum-derive",
+]
+
+[[package]]
+name = "nvml-wrapper-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd23dbe2eb8d8335d2bce0299e0a07d6a63c089243d626ca75b770a962ff49e6"
+dependencies = [
+ "libloading 0.8.8",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4180,6 +4239,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5455,6 +5520,18 @@ name = "wit-bindgen"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
+
+[[package]]
+name = "wrapcenum-derive"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a76ff259533532054cfbaefb115c613203c73707017459206380f03b3b3f266e"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "writeable"

--- a/rust/discover/Cargo.toml
+++ b/rust/discover/Cargo.toml
@@ -6,6 +6,8 @@ edition = "2021"
 [dependencies]
 cfg-if = "1.0"
 sysinfo = { version = "0.30", default-features = false }
+[target.'cfg(target_os = "linux")'.dependencies]
+nvml-wrapper = "0.11"
 
 [dev-dependencies]
 base64 = "0.21"

--- a/rust/discover/src/linux.rs
+++ b/rust/discover/src/linux.rs
@@ -1,8 +1,13 @@
-use crate::{GpuInfo, MemInfo, CPU};
+use crate::{path, GpuInfo, MemInfo, CPU};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
+
+use nvml_wrapper::{
+    bitmasks::InitFlags, cuda_driver_version_major, cuda_driver_version_minor, error::NvmlError,
+    Nvml,
+};
 
 pub fn get_cpu_mem() -> io::Result<MemInfo> {
     let mut mem = MemInfo::default();
@@ -76,10 +81,84 @@ pub fn get_cpu_mem() -> io::Result<MemInfo> {
 }
 
 pub fn get_gpu_info() -> Vec<GpuInfo> {
+    let nvml = match Nvml::init_with_flags(InitFlags::NO_GPUS | InitFlags::NO_ATTACH) {
+        Ok(nvml) => nvml,
+        Err(_) => return cpu_fallback(),
+    };
+
+    let result = collect_cuda_info(&nvml);
+    let _ = nvml.shutdown();
+
+    match result {
+        Ok(gpus) if !gpus.is_empty() => gpus,
+        _ => cpu_fallback(),
+    }
+}
+
+fn collect_cuda_info(nvml: &Nvml) -> Result<Vec<GpuInfo>, NvmlError> {
+    let device_count = nvml.device_count()?;
+    if device_count == 0 {
+        return Ok(Vec::new());
+    }
+
+    let (driver_major, driver_minor, variant) = match nvml.sys_cuda_driver_version() {
+        Ok(version) => {
+            let major = cuda_driver_version_major(version);
+            let minor = cuda_driver_version_minor(version);
+            let variant = if major > 0 {
+                format!("v{}", major)
+            } else {
+                String::new()
+            };
+            (major, minor, variant)
+        }
+        Err(_) => (0, 0, String::new()),
+    };
+    let dependency_paths = path::default_dependency_paths("cuda", &variant);
+
+    let mut gpus = Vec::with_capacity(device_count as usize);
+
+    for index in 0..device_count {
+        let device = nvml.device_by_index(index)?;
+        let memory = device.memory_info()?;
+
+        let mem_info = MemInfo {
+            total_memory: memory.total,
+            free_memory: memory.free,
+            free_swap: 0,
+        };
+
+        let id = device.uuid().unwrap_or_else(|_| format!("gpu-{}", index));
+        let name = device.name().unwrap_or_else(|_| "NVIDIA GPU".to_string());
+        let compute = device
+            .cuda_compute_capability()
+            .map(|cap| format!("{}.{}", cap.major, cap.minor))
+            .unwrap_or_default();
+
+        gpus.push(GpuInfo {
+            mem_info,
+            library: "cuda".into(),
+            variant: variant.clone(),
+            dependency_path: dependency_paths.clone(),
+            id,
+            name,
+            compute,
+            driver_major,
+            driver_minor,
+            ..Default::default()
+        });
+    }
+
+    Ok(gpus)
+}
+
+fn cpu_fallback() -> Vec<GpuInfo> {
     let mem = get_cpu_mem().unwrap_or_default();
+    let dependency_path = path::default_dependency_paths("cpu", "");
     vec![GpuInfo {
         mem_info: mem,
         library: "cpu".into(),
+        dependency_path,
         ..Default::default()
     }]
 }


### PR DESCRIPTION
## Summary
- add nvml-wrapper as a Linux-only dependency for the discover crate
- replace the Linux GPU discovery fallback with NVML-backed device enumeration
- keep a CPU-based fallback when NVML is unavailable and provide dependency paths for each variant

## Testing
- cargo test -p discover

------
https://chatgpt.com/codex/tasks/task_b_68cef6772698832fb212baa689232fcb