### PR TITLE
Implement Metal GPU discovery on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,6 +413,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -750,6 +756,17 @@ name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation",
+ "libc",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -1118,7 +1135,9 @@ dependencies = [
  "bindgen",
  "cfg-if",
  "libloading 0.8.8",
+ "metal",
  "nvml-wrapper",
+ "objc",
  "sysinfo",
 ]
 
@@ -1377,7 +1396,28 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
 dependencies = [
- "foreign-types-shared",
+ "foreign-types-shared 0.1.1",
+]
+
+[[package]]
+name = "foreign-types"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d737d9aa519fb7b749cbc3b962edcf310a8dd1f4b67c91c4f83975dbdd17d965"
+dependencies = [
+ "foreign-types-macros",
+ "foreign-types-shared 0.3.1",
+]
+
+[[package]]
+name = "foreign-types-macros"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1385,6 +1425,12 @@ name = "foreign-types-shared"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2540,6 +2586,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2577,6 +2632,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3572083504c43e14aec05447f8a3d57cce0f66d7a3c1b9058572eca4d70ab9"
+dependencies = [
+ "bitflags 2.9.4",
+ "block",
+ "core-graphics-types",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -2890,6 +2960,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+]
+
+[[package]]
 name = "objc2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3025,7 +3104,7 @@ checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
  "bitflags 2.9.4",
  "cfg-if",
- "foreign-types",
+ "foreign-types 0.3.2",
  "libc",
  "once_cell",
  "openssl-macros",

--- a/rust/discover/Cargo.toml
+++ b/rust/discover/Cargo.toml
@@ -20,5 +20,9 @@ bindgen = "0.69"
 nvml-wrapper = "0.11"
 libloading = "0.8"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+metal = "0.30"
+objc = "0.2"
+
 [dev-dependencies]
 base64 = "0.21"

--- a/rust/discover/src/darwin.rs
+++ b/rust/discover/src/darwin.rs
@@ -1,4 +1,7 @@
 use crate::{GpuInfo, MemInfo};
+use metal::Device;
+use objc::rc::autoreleasepool;
+use std::panic::{self, AssertUnwindSafe};
 use sysinfo::SystemExt;
 
 pub fn get_cpu_mem() -> std::io::Result<MemInfo> {
@@ -12,10 +15,82 @@ pub fn get_cpu_mem() -> std::io::Result<MemInfo> {
 }
 
 pub fn get_gpu_info() -> Vec<GpuInfo> {
-    let mem = get_cpu_mem().unwrap_or_default();
+    let cpu_mem = get_cpu_mem().unwrap_or_default();
+
+    let metal_devices = panic::catch_unwind(AssertUnwindSafe(|| {
+        autoreleasepool(|| {
+            let dependency_paths = crate::path::default_dependency_paths("metal", "");
+            collect_metal_devices(&dependency_paths)
+        })
+    }));
+
+    if let Ok(gpus) = metal_devices {
+        if !gpus.is_empty() {
+            return gpus;
+        }
+    }
+
+    cpu_fallback_with_mem(cpu_mem)
+}
+
+fn collect_metal_devices(dependency_paths: &[String]) -> Vec<GpuInfo> {
+    let mut devices = Device::all();
+    if devices.is_empty() {
+        if let Some(device) = Device::system_default() {
+            devices.push(device);
+        }
+    }
+
+    let mut infos = Vec::with_capacity(devices.len());
+
+    for device in devices {
+        infos.push(build_gpu_info(device, dependency_paths));
+    }
+
+    infos
+}
+
+fn build_gpu_info(device: Device, dependency_paths: &[String]) -> GpuInfo {
+    let recommended = device.recommended_max_working_set_size();
+    let allocated = device.current_allocated_size();
+
+    let free_memory = recommended.saturating_sub(allocated);
+
+    let mut variant_tags = Vec::new();
+    if device.is_low_power() {
+        variant_tags.push("low_power");
+    }
+    if device.is_headless() {
+        variant_tags.push("headless");
+    }
+    if device.is_removable() {
+        variant_tags.push("removable");
+    }
+    let variant = variant_tags.join("_");
+
+    GpuInfo {
+        mem_info: MemInfo {
+            total_memory: recommended,
+            free_memory,
+            free_swap: 0,
+        },
+        library: "metal".into(),
+        variant,
+        minimum_memory: recommended,
+        dependency_path: dependency_paths.to_vec(),
+        unreliable_free_memory: recommended == 0,
+        id: format!("metal-0x{:x}", device.registry_id()),
+        name: device.name().to_string(),
+        ..Default::default()
+    }
+}
+
+fn cpu_fallback_with_mem(mem: MemInfo) -> Vec<GpuInfo> {
+    let dependency_path = crate::path::default_dependency_paths("cpu", "");
     vec![GpuInfo {
         mem_info: mem,
         library: "cpu".into(),
+        dependency_path,
         ..Default::default()
     }]
 }


### PR DESCRIPTION
## Summary
- add macOS-specific Metal/Objective-C dependencies to the discover crate
- enumerate Metal devices to populate GPU metadata on macOS with graceful CPU fallback

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_b_68cf38e78770832fa7ed6d8c1feab92f