### PR TITLE
Add Linux GPU discovery test shims and fallback coverage

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -186,6 +186,11 @@ To run tests, use Cargo:
 cargo test --all
 ```
 
+On Linux, the GPU discovery tests in `rust/discover` rely on built-in shims that
+mock NVML, HIP, and Level Zero enumeration. They do not require setting any
+environment variables or installing GPU runtime libraries; the tests manage
+their overrides internally.
+
 Format and lint the workspace before submitting changes:
 
 ```shell

--- a/rust/discover/src/linux.rs
+++ b/rust/discover/src/linux.rs
@@ -3,6 +3,7 @@ use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::{self, BufRead, BufReader};
 use std::path::Path;
+use std::sync::{Mutex, OnceLock};
 
 use nvml_wrapper::{
     bitmasks::InitFlags, cuda_driver_version_major, cuda_driver_version_minor, error::NvmlError,
@@ -123,6 +124,10 @@ pub fn get_gpu_info() -> Vec<GpuInfo> {
 }
 
 fn collect_cuda_info(nvml: &Nvml) -> Result<Vec<GpuInfo>, NvmlError> {
+    if let Some(overridden) = cuda_override() {
+        return Ok(overridden);
+    }
+
     let device_count = nvml.device_count()?;
     if device_count == 0 {
         return Ok(Vec::new());
@@ -141,9 +146,8 @@ fn collect_cuda_info(nvml: &Nvml) -> Result<Vec<GpuInfo>, NvmlError> {
         }
         Err(_) => (0, 0, String::new()),
     };
-    let dependency_paths = path::default_dependency_paths("cuda", &variant);
 
-    let mut gpus = Vec::with_capacity(device_count as usize);
+    let mut devices = Vec::with_capacity(device_count as usize);
 
     for index in 0..device_count {
         let device = nvml.device_by_index(index)?;
@@ -162,21 +166,18 @@ fn collect_cuda_info(nvml: &Nvml) -> Result<Vec<GpuInfo>, NvmlError> {
             .map(|cap| format!("{}.{}", cap.major, cap.minor))
             .unwrap_or_default();
 
-        gpus.push(GpuInfo {
+        devices.push(GpuDeviceDetails {
             mem_info,
-            library: "cuda".into(),
-            variant: variant.clone(),
-            dependency_path: dependency_paths.clone(),
             id,
             name,
             compute,
             driver_major,
             driver_minor,
-            ..Default::default()
+            variant: variant.clone(),
         });
     }
 
-    Ok(gpus)
+    Ok(finalize_gpu_info("cuda", devices))
 }
 
 fn cpu_fallback() -> Vec<GpuInfo> {
@@ -190,9 +191,221 @@ fn cpu_fallback() -> Vec<GpuInfo> {
     }]
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) struct GpuDeviceDetails {
+    pub mem_info: MemInfo,
+    pub id: String,
+    pub name: String,
+    pub compute: String,
+    pub driver_major: i32,
+    pub driver_minor: i32,
+    pub variant: String,
+}
+
+pub(super) fn finalize_gpu_info(library: &str, devices: Vec<GpuDeviceDetails>) -> Vec<GpuInfo> {
+    devices
+        .into_iter()
+        .map(|details| GpuInfo {
+            mem_info: details.mem_info,
+            library: library.into(),
+            variant: details.variant.clone(),
+            dependency_path: path::default_dependency_paths(library, &details.variant),
+            id: details.id,
+            name: details.name,
+            compute: details.compute,
+            driver_major: details.driver_major,
+            driver_minor: details.driver_minor,
+            ..Default::default()
+        })
+        .collect()
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(super) enum OverrideKind {
+    Cuda,
+    Hip,
+    OneApi,
+}
+
+static CUDA_OVERRIDE: OnceLock<Mutex<Option<Vec<GpuInfo>>>> = OnceLock::new();
+static HIP_OVERRIDE: OnceLock<Mutex<Option<Vec<GpuInfo>>>> = OnceLock::new();
+static ONEAPI_OVERRIDE: OnceLock<Mutex<Option<Vec<GpuInfo>>>> = OnceLock::new();
+
+fn override_storage(kind: OverrideKind) -> &'static Mutex<Option<Vec<GpuInfo>>> {
+    match kind {
+        OverrideKind::Cuda => CUDA_OVERRIDE.get_or_init(|| Mutex::new(None)),
+        OverrideKind::Hip => HIP_OVERRIDE.get_or_init(|| Mutex::new(None)),
+        OverrideKind::OneApi => ONEAPI_OVERRIDE.get_or_init(|| Mutex::new(None)),
+    }
+}
+
+pub(super) fn set_override(
+    kind: OverrideKind,
+    value: Option<Vec<GpuInfo>>,
+) -> Option<Vec<GpuInfo>> {
+    let storage = override_storage(kind);
+    let mut guard = storage.lock().unwrap();
+    let previous = guard.clone();
+    *guard = value;
+    previous
+}
+
+fn current_override(kind: OverrideKind) -> Option<Vec<GpuInfo>> {
+    let storage = override_storage(kind);
+    storage.lock().unwrap().clone()
+}
+
+pub(super) fn cuda_override() -> Option<Vec<GpuInfo>> {
+    current_override(OverrideKind::Cuda)
+}
+
+#[cfg(feature = "linux-rocm")]
+pub(super) fn hip_override() -> Option<Vec<GpuInfo>> {
+    current_override(OverrideKind::Hip)
+}
+
+pub(super) fn oneapi_override() -> Option<Vec<GpuInfo>> {
+    current_override(OverrideKind::OneApi)
+}
+
+pub mod test_support {
+    use super::{finalize_gpu_info, set_override, GpuDeviceDetails, MemInfo, OverrideKind};
+
+    #[derive(Debug, Clone, PartialEq, Eq)]
+    pub struct MockDevice {
+        pub id: String,
+        pub name: String,
+        pub mem_info: MemInfo,
+        pub compute: String,
+        pub driver_major: i32,
+        pub driver_minor: i32,
+        pub variant: String,
+    }
+
+    impl MockDevice {
+        #[allow(clippy::too_many_arguments)]
+        pub fn new(
+            id: impl Into<String>,
+            name: impl Into<String>,
+            mem_info: MemInfo,
+            compute: impl Into<String>,
+            driver_major: i32,
+            driver_minor: i32,
+            variant: impl Into<String>,
+        ) -> Self {
+            Self {
+                id: id.into(),
+                name: name.into(),
+                mem_info,
+                compute: compute.into(),
+                driver_major,
+                driver_minor,
+                variant: variant.into(),
+            }
+        }
+    }
+
+    fn to_details(device: MockDevice) -> GpuDeviceDetails {
+        GpuDeviceDetails {
+            mem_info: device.mem_info,
+            id: device.id,
+            name: device.name,
+            compute: device.compute,
+            driver_major: device.driver_major,
+            driver_minor: device.driver_minor,
+            variant: device.variant,
+        }
+    }
+
+    pub fn build_gpu_info(library: &str, devices: Vec<MockDevice>) -> Vec<crate::GpuInfo> {
+        finalize_gpu_info(library, devices.into_iter().map(to_details).collect())
+    }
+
+    pub fn build_cuda_info(
+        devices: Vec<MockDevice>,
+        driver_major: i32,
+        driver_minor: i32,
+    ) -> Vec<crate::GpuInfo> {
+        let variant = if driver_major > 0 {
+            format!("v{}", driver_major)
+        } else {
+            String::new()
+        };
+        let devices = devices
+            .into_iter()
+            .map(|mut device| {
+                device.driver_major = driver_major;
+                device.driver_minor = driver_minor;
+                device.variant = variant.clone();
+                device
+            })
+            .collect();
+        build_gpu_info("cuda", devices)
+    }
+
+    pub fn build_rocm_info(
+        mut devices: Vec<MockDevice>,
+        driver_major: i32,
+        driver_minor: i32,
+        runtime_major: Option<i32>,
+    ) -> Vec<crate::GpuInfo> {
+        let variant = runtime_major
+            .filter(|major| *major > 0)
+            .map(|major| format!("v{}", major))
+            .unwrap_or_default();
+        for device in &mut devices {
+            device.driver_major = driver_major;
+            device.driver_minor = driver_minor;
+            device.variant = variant.clone();
+        }
+        build_gpu_info("rocm", devices)
+    }
+
+    pub fn build_oneapi_info(devices: Vec<MockDevice>) -> Vec<crate::GpuInfo> {
+        build_gpu_info("oneapi", devices)
+    }
+
+    #[derive(Debug)]
+    pub struct OverrideGuard {
+        kind: OverrideKind,
+        previous: Option<Vec<crate::GpuInfo>>,
+    }
+
+    impl OverrideGuard {
+        fn new(kind: OverrideKind, value: Option<Vec<crate::GpuInfo>>) -> Self {
+            let previous = set_override(kind, value);
+            Self { kind, previous }
+        }
+    }
+
+    impl Drop for OverrideGuard {
+        fn drop(&mut self) {
+            let _ = set_override(self.kind, self.previous.clone());
+        }
+    }
+
+    pub fn override_cuda(value: Option<Vec<crate::GpuInfo>>) -> OverrideGuard {
+        OverrideGuard::new(OverrideKind::Cuda, value)
+    }
+
+    pub fn override_hip(value: Option<Vec<crate::GpuInfo>>) -> OverrideGuard {
+        OverrideGuard::new(OverrideKind::Hip, value)
+    }
+
+    pub fn override_oneapi(value: Option<Vec<crate::GpuInfo>>) -> OverrideGuard {
+        OverrideGuard::new(OverrideKind::OneApi, value)
+    }
+
+    pub fn clear_overrides() {
+        let _ = set_override(OverrideKind::Cuda, None);
+        let _ = set_override(OverrideKind::Hip, None);
+        let _ = set_override(OverrideKind::OneApi, None);
+    }
+}
+
 mod oneapi {
-    use super::oneapi_bindings as ze;
-    use crate::{path, GpuInfo, MemInfo};
+    use super::{finalize_gpu_info, oneapi_bindings as ze, oneapi_override, GpuDeviceDetails};
+    use crate::MemInfo;
     use libloading::Library;
     use std::ffi::CStr;
     use std::os::raw::{c_char, c_void};
@@ -225,7 +438,11 @@ mod oneapi {
         *mut ze::ze_driver_properties_t,
     ) -> ze::ze_result_t;
 
-    pub(super) fn collect_oneapi_info() -> Result<Vec<GpuInfo>, String> {
+    pub(super) fn collect_oneapi_info() -> Result<Vec<crate::GpuInfo>, String> {
+        if let Some(overridden) = oneapi_override() {
+            return Ok(overridden);
+        }
+
         let library = OneApiLibrary::load()?;
         unsafe { library.enumerate_devices() }
     }
@@ -278,7 +495,7 @@ mod oneapi {
             })
         }
 
-        unsafe fn enumerate_devices(&self) -> Result<Vec<GpuInfo>, String> {
+        unsafe fn enumerate_devices(&self) -> Result<Vec<crate::GpuInfo>, String> {
             ze_check((self.zes_init)(0), "zesInit")?;
 
             let mut driver_count: u32 = 0;
@@ -345,33 +562,29 @@ mod oneapi {
                         driver_minor = minor;
                     }
 
+                    let id = properties
+                        .uuid
+                        .unwrap_or_else(|| format!("oneapi-{}-{}", driver_index, device_index));
+
                     let variant = if driver_major > 0 {
                         format!("v{}", driver_major)
                     } else {
                         String::new()
                     };
-                    let dependency_paths = path::default_dependency_paths("oneapi", &variant);
 
-                    let id = properties
-                        .uuid
-                        .unwrap_or_else(|| format!("oneapi-{}-{}", driver_index, device_index));
-
-                    gpus.push(GpuInfo {
+                    gpus.push(GpuDeviceDetails {
                         mem_info,
-                        library: "oneapi".into(),
-                        variant,
-                        dependency_path: dependency_paths,
                         id,
                         name: properties.name,
                         compute: String::new(),
                         driver_major,
                         driver_minor,
-                        ..Default::default()
+                        variant,
                     });
                 }
             }
 
-            Ok(gpus)
+            Ok(finalize_gpu_info("oneapi", gpus))
         }
 
         unsafe fn driver_details(
@@ -518,7 +731,7 @@ mod oneapi {
         }
     }
 
-    fn parse_driver_version(version: &str) -> Option<(i32, i32)> {
+    pub(super) fn parse_driver_version(version: &str) -> Option<(i32, i32)> {
         let mut parts = version
             .split(|c: char| !c.is_ascii_digit())
             .filter(|s| !s.is_empty());

--- a/rust/discover/src/linux/hip.rs
+++ b/rust/discover/src/linux/hip.rs
@@ -1,4 +1,5 @@
-use crate::{path, GpuInfo, MemInfo};
+use super::{finalize_gpu_info, hip_override, GpuDeviceDetails};
+use crate::MemInfo;
 use libloading::Library;
 use std::ffi::CStr;
 use std::os::raw::{c_char, c_int, c_uint};
@@ -24,7 +25,11 @@ type HipRuntimeGetVersion = unsafe extern "C" fn(*mut c_int) -> hipError_t;
 type HipDriverGetVersion = unsafe extern "C" fn(*mut c_int) -> hipError_t;
 type HipDeviceGetPCIBusId = unsafe extern "C" fn(*mut c_char, c_int, hipDevice_t) -> hipError_t;
 
-pub(super) fn collect_hip_info() -> Result<Vec<GpuInfo>, String> {
+pub(super) fn collect_hip_info() -> Result<Vec<crate::GpuInfo>, String> {
+    if let Some(overridden) = hip_override() {
+        return Ok(overridden);
+    }
+
     let library = match HipLibrary::load() {
         Ok(lib) => lib,
         Err(err) => return Err(err),
@@ -94,7 +99,7 @@ impl HipLibrary {
         })
     }
 
-    unsafe fn enumerate_devices(&self) -> Result<Vec<GpuInfo>, String> {
+    unsafe fn enumerate_devices(&self) -> Result<Vec<crate::GpuInfo>, String> {
         hip_check((self.hip_init)(0), "hipInit")?;
 
         let mut count: c_int = 0;
@@ -109,9 +114,8 @@ impl HipLibrary {
 
         let (driver_major, driver_minor) = self.driver_version();
         let variant = self.runtime_variant();
-        let dependency_paths = path::default_dependency_paths("rocm", &variant);
 
-        let mut gpus = Vec::with_capacity(count as usize);
+        let mut devices = Vec::with_capacity(count as usize);
 
         for ordinal in 0..count {
             let mut device: hipDevice_t = 0;
@@ -132,21 +136,18 @@ impl HipLibrary {
             };
             let compute = self.device_compute_capability(device).unwrap_or_default();
 
-            gpus.push(GpuInfo {
+            devices.push(GpuDeviceDetails {
                 mem_info,
-                library: "rocm".into(),
-                variant: variant.clone(),
-                dependency_path: dependency_paths.clone(),
                 id,
                 name,
                 compute,
                 driver_major,
                 driver_minor,
-                ..Default::default()
+                variant: variant.clone(),
             });
         }
 
-        Ok(gpus)
+        Ok(finalize_gpu_info("rocm", devices))
     }
 
     unsafe fn device_name(&self, device: hipDevice_t) -> Result<String, String> {

--- a/rust/discover/tests/gpu_linux_paths.rs
+++ b/rust/discover/tests/gpu_linux_paths.rs
@@ -1,0 +1,116 @@
+#![cfg(target_os = "linux")]
+
+#[cfg(feature = "linux-rocm")]
+use discover::test_support::build_rocm_info;
+use discover::test_support::{
+    build_cuda_info, build_oneapi_info, override_cuda, override_hip, override_oneapi, MockDevice,
+};
+use discover::{get_gpu_info, path, MemInfo};
+
+#[test]
+fn test_cuda_mock_devices_populate_gpu_info() {
+    let base_mem = MemInfo {
+        total_memory: 16 * 1024,
+        free_memory: 8 * 1024,
+        free_swap: 0,
+    };
+    let devices = vec![MockDevice::new(
+        "gpu-0",
+        "Test CUDA",
+        base_mem.clone(),
+        "8.0",
+        0,
+        0,
+        "",
+    )];
+
+    let info = build_cuda_info(devices, 12, 4);
+    assert_eq!(info.len(), 1);
+    let gpu = &info[0];
+    assert_eq!(gpu.library, "cuda");
+    assert_eq!(gpu.variant, "v12");
+    assert_eq!(gpu.id, "gpu-0");
+    assert_eq!(gpu.name, "Test CUDA");
+    assert_eq!(gpu.compute, "8.0");
+    assert_eq!(gpu.driver_major, 12);
+    assert_eq!(gpu.driver_minor, 4);
+    assert_eq!(gpu.mem_info, base_mem);
+    assert_eq!(
+        gpu.dependency_path,
+        path::default_dependency_paths("cuda", "v12"),
+    );
+}
+
+#[cfg(feature = "linux-rocm")]
+#[test]
+fn test_rocm_mock_devices_populate_gpu_info() {
+    let base_mem = MemInfo {
+        total_memory: 32 * 1024,
+        free_memory: 12 * 1024,
+        free_swap: 0,
+    };
+    let devices = vec![MockDevice::new(
+        "hip-0",
+        "Test ROCm",
+        base_mem.clone(),
+        "9.0",
+        0,
+        0,
+        "",
+    )];
+
+    let info = build_rocm_info(devices, 5, 1, Some(6));
+    assert_eq!(info.len(), 1);
+    let gpu = &info[0];
+    assert_eq!(gpu.library, "rocm");
+    assert_eq!(gpu.variant, "v6");
+    assert_eq!(gpu.driver_major, 5);
+    assert_eq!(gpu.driver_minor, 1);
+    assert_eq!(gpu.mem_info, base_mem);
+    assert_eq!(
+        gpu.dependency_path,
+        path::default_dependency_paths("rocm", "v6"),
+    );
+}
+
+#[test]
+fn test_oneapi_mock_devices_populate_gpu_info() {
+    let base_mem = MemInfo {
+        total_memory: 24 * 1024,
+        free_memory: 10 * 1024,
+        free_swap: 0,
+    };
+    let devices = vec![MockDevice::new(
+        "oneapi-0",
+        "Level Zero",
+        base_mem.clone(),
+        String::new(),
+        7,
+        3,
+        "v7",
+    )];
+
+    let info = build_oneapi_info(devices);
+    assert_eq!(info.len(), 1);
+    let gpu = &info[0];
+    assert_eq!(gpu.library, "oneapi");
+    assert_eq!(gpu.variant, "v7");
+    assert_eq!(gpu.driver_major, 7);
+    assert_eq!(gpu.driver_minor, 3);
+    assert_eq!(gpu.mem_info, base_mem);
+    assert_eq!(
+        gpu.dependency_path,
+        path::default_dependency_paths("oneapi", "v7"),
+    );
+}
+
+#[test]
+fn test_cpu_fallback_when_no_gpu_libraries() {
+    let _cuda_guard = override_cuda(Some(Vec::new()));
+    let _hip_guard = override_hip(Some(Vec::new()));
+    let _oneapi_guard = override_oneapi(Some(Vec::new()));
+
+    let gpus = get_gpu_info();
+    assert_eq!(gpus.len(), 1);
+    assert_eq!(gpus[0].library, "cpu");
+}


### PR DESCRIPTION
## Summary
- add reusable GPU device detail helpers and override hooks for the Linux CUDA, HIP, and Level Zero collectors
- implement linux-only integration tests that mock each GPU path and verify CPU fallback behaviour
- document that the new Linux GPU tests rely on built-in shims with no extra environment setup

## Testing
- cargo test -p discover

------
https://chatgpt.com/codex/tasks/task_b_68d0338b7ce0832f88e26447f3c03d43