### PR TITLE
Add mockable Windows GPU loaders and unit tests

### DIFF
--- a/rust/discover/src/windows.rs
+++ b/rust/discover/src/windows.rs
@@ -154,21 +154,42 @@ pub fn get_cpu_mem() -> std::io::Result<MemInfo> {
     })
 }
 
+pub struct GpuLoaders<'a> {
+    cuda: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+    hip: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+    oneapi: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+}
+
+impl<'a> GpuLoaders<'a> {
+    pub fn new(
+        cuda: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+        hip: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+        oneapi: &'a dyn Fn() -> Result<Vec<GpuInfo>, String>,
+    ) -> Self {
+        Self { cuda, hip, oneapi }
+    }
+}
+
+fn default_loaders() -> GpuLoaders<'static> {
+    GpuLoaders::new(&load_cuda, &hip::collect_hip_info, &oneapi::collect_oneapi_info)
+}
+
 pub fn get_gpu_info() -> Vec<GpuInfo> {
+    get_gpu_info_with(&default_loaders())
+}
+
+pub fn get_gpu_info_with(loaders: &GpuLoaders) -> Vec<GpuInfo> {
     let mut gpus = Vec::new();
 
-    if let Ok(nvml) = Nvml::init_with_flags(InitFlags::NO_GPUS | InitFlags::NO_ATTACH) {
-        if let Ok(mut cuda_gpus) = collect_cuda_info(&nvml) {
-            gpus.append(&mut cuda_gpus);
-        }
-        let _ = nvml.shutdown();
+    if let Ok(mut cuda_gpus) = (loaders.cuda)() {
+        gpus.append(&mut cuda_gpus);
     }
 
-    if let Ok(mut hip_gpus) = hip::collect_hip_info() {
+    if let Ok(mut hip_gpus) = (loaders.hip)() {
         gpus.append(&mut hip_gpus);
     }
 
-    if let Ok(mut oneapi_gpus) = oneapi::collect_oneapi_info() {
+    if let Ok(mut oneapi_gpus) = (loaders.oneapi)() {
         gpus.append(&mut oneapi_gpus);
     }
 
@@ -177,6 +198,14 @@ pub fn get_gpu_info() -> Vec<GpuInfo> {
     } else {
         gpus
     }
+}
+
+fn load_cuda() -> Result<Vec<GpuInfo>, String> {
+    let nvml = Nvml::init_with_flags(InitFlags::NO_GPUS | InitFlags::NO_ATTACH)
+        .map_err(|err| err.to_string())?;
+    let result = collect_cuda_info(&nvml).map_err(|err| err.to_string());
+    let _ = nvml.shutdown();
+    result
 }
 
 fn collect_cuda_info(nvml: &Nvml) -> Result<Vec<GpuInfo>, NvmlError> {

--- a/rust/discover/tests/README.md
+++ b/rust/discover/tests/README.md
@@ -1,0 +1,6 @@
+# Windows GPU discovery tests
+
+The Windows-specific GPU discovery tests use the `GpuLoaders` abstraction to
+mock responses from NVML, HIP, and Level Zero. Because the tests simulate the
+vendor libraries, they do **not** need any DLLs on the `PATH` when running in
+CI or local development environments.

--- a/rust/discover/tests/gpu_windows.rs
+++ b/rust/discover/tests/gpu_windows.rs
@@ -2,6 +2,28 @@
 use base64::{engine::general_purpose, Engine as _};
 #[cfg(target_os = "windows")]
 use discover::process_system_logical_processor_information_list;
+#[cfg(target_os = "windows")]
+use discover::{get_gpu_info_with, GpuInfo, GpuLoaders, MemInfo};
+
+#[cfg(target_os = "windows")]
+fn mock_gpu(library: &str, variant: &str, id: &str) -> GpuInfo {
+    GpuInfo {
+        mem_info: MemInfo {
+            total_memory: 16 * 1024,
+            free_memory: 8 * 1024,
+            free_swap: 0,
+        },
+        library: library.to_string(),
+        variant: variant.to_string(),
+        dependency_path: vec![format!("{library}-deps")],
+        id: id.to_string(),
+        name: format!("{} device", library.to_uppercase()),
+        compute: "1.0".into(),
+        driver_major: 1,
+        driver_minor: 2,
+        ..Default::default()
+    }
+}
 
 #[cfg(target_os = "windows")]
 #[test]
@@ -62,4 +84,64 @@ fn test_process_system_logical_processor_information_list() {
             assert_eq!(resp[i].thread_count, pkg.threads, "[{name}] threads");
         }
     }
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_get_gpu_info_with_mock_cuda() {
+    let expected = mock_gpu("cuda", "v12", "cuda-0");
+    let cuda_loader = {
+        let gpu = expected.clone();
+        move || Ok(vec![gpu.clone()])
+    };
+    let failing_loader = || -> Result<Vec<GpuInfo>, String> { Err("missing".into()) };
+
+    let loaders = GpuLoaders::new(&cuda_loader, &failing_loader, &failing_loader);
+    let info = get_gpu_info_with(&loaders);
+
+    assert_eq!(info, vec![expected]);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_get_gpu_info_with_mock_hip() {
+    let expected = mock_gpu("rocm", "v6", "hip-0");
+    let hip_loader = {
+        let gpu = expected.clone();
+        move || Ok(vec![gpu.clone()])
+    };
+    let failing_loader = || -> Result<Vec<GpuInfo>, String> { Err("missing".into()) };
+
+    let loaders = GpuLoaders::new(&failing_loader, &hip_loader, &failing_loader);
+    let info = get_gpu_info_with(&loaders);
+
+    assert_eq!(info, vec![expected]);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_get_gpu_info_with_mock_oneapi() {
+    let expected = mock_gpu("oneapi", "v1", "oneapi-0");
+    let oneapi_loader = {
+        let gpu = expected.clone();
+        move || Ok(vec![gpu.clone()])
+    };
+    let failing_loader = || -> Result<Vec<GpuInfo>, String> { Err("missing".into()) };
+
+    let loaders = GpuLoaders::new(&failing_loader, &failing_loader, &oneapi_loader);
+    let info = get_gpu_info_with(&loaders);
+
+    assert_eq!(info, vec![expected]);
+}
+
+#[cfg(target_os = "windows")]
+#[test]
+fn test_get_gpu_info_fallback_on_failures() {
+    let failing_loader = || -> Result<Vec<GpuInfo>, String> { Err("missing".into()) };
+    let loaders = GpuLoaders::new(&failing_loader, &failing_loader, &failing_loader);
+
+    let info = get_gpu_info_with(&loaders);
+
+    assert_eq!(info.len(), 1);
+    assert_eq!(info[0].library, "cpu");
 }


### PR DESCRIPTION
## Summary
- add a `GpuLoaders` abstraction so Windows GPU discovery can be mocked in tests
- add Windows GPU tests that simulate CUDA, ROCm, and Level Zero responses
- document that the mocked tests do not require DLLs on the PATH

## Testing
- cargo test -p discover

------
https://chatgpt.com/codex/tasks/task_b_68d0529bbfd4832fa806141375362a93