### PR TITLE
Add ggml-core Rust tensor runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,6 +163,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "ascii"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +467,20 @@ name = "bytemuck"
 version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f154e572231cb6ba2bd1176980827e3d5dc04cc183a75dea38109fbdd672d29"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
 
 [[package]]
 name = "byteorder"
@@ -1611,6 +1634,16 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.7+wasi-0.2.4",
+]
+
+[[package]]
+name = "ggml-core"
+version = "0.1.0"
+dependencies = [
+ "approx",
+ "bytemuck",
+ "smallvec",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "rust/discover",
     "rust/envconfig",
     "rust/fs",
+    "rust/ggml-core",
     "rust/harmony",
     "rust/kvcache",
     "rust/llama",
@@ -54,6 +55,7 @@ llm = { path = "rust/llm" }
 logutil = { path = "rust/logutil" }
 model = { path = "rust/model" }
 ml = { path = "rust/ml" }
+ggml-core = { path = "rust/ggml-core" }
 ollama_types = { path = "rust/ollama_types" }
 parser = { path = "rust/parser" }
 progress = { path = "rust/progress" }

--- a/rust/ggml-core/Cargo.toml
+++ b/rust/ggml-core/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ggml-core"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+bytemuck = { version = "1.15", features = ["derive"] }
+smallvec = "1.13"
+thiserror = "1.0"
+
+[dev-dependencies]
+approx = "0.5"

--- a/rust/ggml-core/src/arena.rs
+++ b/rust/ggml-core/src/arena.rs
@@ -1,0 +1,89 @@
+use std::ops::Range;
+
+use bytemuck::{cast_slice, cast_slice_mut};
+
+use crate::{Error, Result};
+
+/// A linear bump-allocated arena mirroring the `ggml` memory model.
+#[derive(Debug)]
+pub struct MemoryArena {
+    buffer: Vec<u8>,
+    offset: usize,
+    alignment: usize,
+}
+
+impl MemoryArena {
+    /// Creates a new arena with the provided capacity and base alignment.
+    pub fn new(capacity: usize, alignment: usize) -> Self {
+        Self {
+            buffer: vec![0; capacity],
+            offset: 0,
+            alignment: alignment.max(1),
+        }
+    }
+
+    /// Returns the total arena capacity in bytes.
+    pub fn capacity(&self) -> usize {
+        self.buffer.len()
+    }
+
+    /// Returns the amount of memory used so far.
+    pub fn used(&self) -> usize {
+        self.offset
+    }
+
+    /// Allocates a contiguous block of memory from the arena.
+    pub fn allocate(&mut self, size: usize, alignment: usize) -> Result<Range<usize>> {
+        let alignment = alignment.max(self.alignment);
+        if alignment.is_power_of_two() {
+            let aligned_offset = align_to(self.offset, alignment);
+            let end = aligned_offset.saturating_add(size);
+            if end > self.buffer.len() {
+                return Err(Error::OutOfMemory {
+                    requested: size,
+                    available: self.buffer.len().saturating_sub(self.offset),
+                });
+            }
+            self.offset = end;
+            Ok(aligned_offset..end)
+        } else {
+            Err(Error::InvalidAlignment(alignment))
+        }
+    }
+
+    /// Writes a raw slice of bytes into the arena at the provided range.
+    pub fn write_bytes(&mut self, range: &Range<usize>, data: &[u8]) {
+        let dst = &mut self.buffer[range.start..range.end];
+        dst.copy_from_slice(data);
+    }
+
+    /// Reads a raw slice of bytes from the arena.
+    pub fn read_bytes(&self, range: &Range<usize>) -> &[u8] {
+        &self.buffer[range.start..range.end]
+    }
+
+    /// Reads a `f32` slice from the arena.
+    pub fn read_f32(&self, range: &Range<usize>) -> &[f32] {
+        cast_slice(self.read_bytes(range))
+    }
+
+    /// Writes a `f32` slice into the arena.
+    pub fn write_f32(&mut self, range: &Range<usize>, values: &[f32]) {
+        let dst = &mut self.buffer[range.start..range.end];
+        let dst_f32 = cast_slice_mut(dst);
+        dst_f32.copy_from_slice(values);
+    }
+
+    /// Resets the arena so subsequent allocations start from the beginning.
+    pub fn reset(&mut self) {
+        self.offset = 0;
+        for byte in &mut self.buffer {
+            *byte = 0;
+        }
+    }
+}
+
+fn align_to(value: usize, alignment: usize) -> usize {
+    let mask = alignment - 1;
+    (value + mask) & !mask
+}

--- a/rust/ggml-core/src/context.rs
+++ b/rust/ggml-core/src/context.rs
@@ -1,0 +1,366 @@
+use std::{
+    cell::{Cell, RefCell},
+    rc::Rc,
+};
+
+use smallvec::SmallVec;
+
+use crate::{
+    arena::MemoryArena,
+    dtype::DType,
+    error::{Error, Result},
+    ops::{BinaryOpKind, OpKernel, Operation, OperationKind, UnaryOpKind},
+    tensor::{Shape, Tensor, TensorData, TensorId},
+};
+
+#[derive(Clone, Debug)]
+pub struct Context {
+    pub(crate) inner: Rc<ContextInner>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ContextInner {
+    pub(crate) arena: RefCell<MemoryArena>,
+    pub(crate) tensors: RefCell<Vec<TensorData>>,
+    next_id: Cell<usize>,
+}
+
+#[derive(Clone, Debug)]
+pub struct ContextParams {
+    pub memory_size: usize,
+    pub memory_alignment: usize,
+}
+
+impl Default for ContextParams {
+    fn default() -> Self {
+        Self {
+            memory_size: 16 * 1024 * 1024,
+            memory_alignment: 32,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct ContextBuilder {
+    params: ContextParams,
+}
+
+impl Default for ContextBuilder {
+    fn default() -> Self {
+        Self {
+            params: ContextParams::default(),
+        }
+    }
+}
+
+impl ContextBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn memory_size(mut self, bytes: usize) -> Self {
+        self.params.memory_size = bytes;
+        self
+    }
+
+    pub fn memory_alignment(mut self, alignment: usize) -> Self {
+        self.params.memory_alignment = alignment;
+        self
+    }
+
+    pub fn build(self) -> Context {
+        Context::new(self.params)
+    }
+}
+
+impl Context {
+    pub fn new(params: ContextParams) -> Self {
+        let arena = MemoryArena::new(params.memory_size, params.memory_alignment);
+        Self {
+            inner: Rc::new(ContextInner {
+                arena: RefCell::new(arena),
+                tensors: RefCell::new(Vec::new()),
+                next_id: Cell::new(0),
+            }),
+        }
+    }
+
+    pub fn builder() -> ContextBuilder {
+        ContextBuilder::default()
+    }
+
+    pub fn tensor_from_f32(&self, shape: &[usize], data: &[f32]) -> Result<Tensor> {
+        let shape_vec = shape_from_slice(shape)?;
+        let expected = shape_vec.iter().product::<usize>();
+        if expected != data.len() {
+            return Err(Error::ShapeMismatch {
+                expected: shape_vec.iter().copied().collect(),
+                actual: vec![data.len()],
+            });
+        }
+        let bytes = data.len() * std::mem::size_of::<f32>();
+        let storage = {
+            let mut arena = self.inner.arena.borrow_mut();
+            let range = arena.allocate(bytes, DType::F32.alignment())?;
+            arena.write_f32(&range, data);
+            range
+        };
+        Ok(self.register_tensor(shape_vec, DType::F32, Operation::constant(), storage, true))
+    }
+
+    pub fn tensor_zeroed(&self, shape: &[usize]) -> Result<Tensor> {
+        let shape_vec = shape_from_slice(shape)?;
+        let numel = shape_vec.iter().product::<usize>();
+        let zeros = vec![0.0f32; numel];
+        self.tensor_from_f32(shape, &zeros)
+    }
+
+    pub fn parameter(&self, shape: &[usize]) -> Result<Tensor> {
+        let shape_vec = shape_from_slice(shape)?;
+        let numel = shape_vec.iter().product::<usize>();
+        let bytes = numel * DType::F32.size_in_bytes();
+        let storage = {
+            let mut arena = self.inner.arena.borrow_mut();
+            arena.allocate(bytes, DType::F32.alignment())?
+        };
+        Ok(self.register_tensor(
+            shape_vec,
+            DType::F32,
+            Operation::parameter(),
+            storage,
+            false,
+        ))
+    }
+
+    pub(crate) fn binary_op(
+        &self,
+        lhs: &Tensor,
+        rhs: &Tensor,
+        kind: BinaryOpKind,
+    ) -> Result<Tensor> {
+        self.assert_same_context(lhs)?;
+        self.assert_same_context(rhs)?;
+        let lhs_shape = self.tensor_shape(lhs.id);
+        let rhs_shape = self.tensor_shape(rhs.id);
+        if lhs_shape != rhs_shape {
+            return Err(Error::ShapeMismatch {
+                expected: lhs_shape.iter().copied().collect(),
+                actual: rhs_shape.iter().copied().collect(),
+            });
+        }
+        let dtype = self.tensor_dtype(lhs.id);
+        let rhs_dtype = self.tensor_dtype(rhs.id);
+        if dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, dtype));
+        }
+        if rhs_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, rhs_dtype));
+        }
+        let numel = lhs_shape.iter().product::<usize>();
+        let bytes = numel * dtype.size_in_bytes();
+        let storage = {
+            let mut arena = self.inner.arena.borrow_mut();
+            arena.allocate(bytes, dtype.alignment())?
+        };
+        Ok(self.register_tensor(
+            lhs_shape,
+            dtype,
+            Operation::binary(kind, lhs.id, rhs.id),
+            storage,
+            false,
+        ))
+    }
+
+    pub(crate) fn unary_op(&self, input: &Tensor, kind: UnaryOpKind) -> Result<Tensor> {
+        self.assert_same_context(input)?;
+        let shape = self.tensor_shape(input.id);
+        let dtype = self.tensor_dtype(input.id);
+        if dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, dtype));
+        }
+        let numel = shape.iter().product::<usize>();
+        let bytes = numel * dtype.size_in_bytes();
+        let storage = {
+            let mut arena = self.inner.arena.borrow_mut();
+            arena.allocate(bytes, dtype.alignment())?
+        };
+        Ok(self.register_tensor(
+            shape,
+            dtype,
+            Operation::unary(kind, input.id),
+            storage,
+            false,
+        ))
+    }
+
+    pub(crate) fn matmul(&self, lhs: &Tensor, rhs: &Tensor) -> Result<Tensor> {
+        self.assert_same_context(lhs)?;
+        self.assert_same_context(rhs)?;
+        let lhs_shape = self.tensor_shape(lhs.id);
+        let rhs_shape = self.tensor_shape(rhs.id);
+        if lhs_shape.len() != 2 || rhs_shape.len() != 2 {
+            return Err(Error::Operation("matmul expects 2D tensors".into()));
+        }
+        if lhs_shape[1] != rhs_shape[0] {
+            return Err(Error::Operation("matmul inner dimensions mismatch".into()));
+        }
+        let out_shape: Shape = SmallVec::from_slice(&[lhs_shape[0], rhs_shape[1]]);
+        let dtype = self.tensor_dtype(lhs.id);
+        let rhs_dtype = self.tensor_dtype(rhs.id);
+        if dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, dtype));
+        }
+        if rhs_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, rhs_dtype));
+        }
+        let numel = out_shape.iter().product::<usize>();
+        let bytes = numel * dtype.size_in_bytes();
+        let storage = {
+            let mut arena = self.inner.arena.borrow_mut();
+            arena.allocate(bytes, dtype.alignment())?
+        };
+        Ok(self.register_tensor(
+            out_shape,
+            dtype,
+            Operation::matmul(lhs.id, rhs.id),
+            storage,
+            false,
+        ))
+    }
+
+    pub(crate) fn tensor_dtype(&self, id: TensorId) -> DType {
+        let tensors = self.inner.tensors.borrow();
+        tensors[id.index()].dtype
+    }
+
+    pub(crate) fn tensor_shape(&self, id: TensorId) -> Shape {
+        let tensors = self.inner.tensors.borrow();
+        tensors[id.index()].shape.clone()
+    }
+
+    pub(crate) fn tensor_elements(&self, id: TensorId) -> usize {
+        let tensors = self.inner.tensors.borrow();
+        tensors[id.index()].elements()
+    }
+
+    pub(crate) fn tensor_to_vec(&self, id: TensorId) -> Result<Vec<f32>> {
+        let storage = {
+            let tensors = self.inner.tensors.borrow();
+            let tensor = &tensors[id.index()];
+            if tensor.dtype != DType::F32 {
+                return Err(Error::dtype_mismatch(DType::F32, tensor.dtype));
+            }
+            tensor.storage()
+        };
+        let arena = self.inner.arena.borrow();
+        Ok(arena.read_f32(&storage).to_vec())
+    }
+
+    pub(crate) fn tensor_set_f32(&self, id: TensorId, data: &[f32]) -> Result<()> {
+        let (storage, shape) = {
+            let tensors = self.inner.tensors.borrow();
+            let tensor = &tensors[id.index()];
+            if tensor.dtype != DType::F32 {
+                return Err(Error::dtype_mismatch(DType::F32, tensor.dtype));
+            }
+            (tensor.storage(), tensor.shape.clone())
+        };
+        let expected = shape.iter().product::<usize>();
+        if expected != data.len() {
+            return Err(Error::ShapeMismatch {
+                expected: shape.iter().copied().collect(),
+                actual: vec![data.len()],
+            });
+        }
+        {
+            let mut arena = self.inner.arena.borrow_mut();
+            arena.write_f32(&storage, data);
+        }
+        {
+            let mut tensors = self.inner.tensors.borrow_mut();
+            tensors[id.index()].mark_computed();
+        }
+        Ok(())
+    }
+
+    pub(crate) fn tensor_set_name(&self, id: TensorId, name: String) -> Result<()> {
+        let mut tensors = self.inner.tensors.borrow_mut();
+        tensors[id.index()].name = Some(name);
+        Ok(())
+    }
+
+    pub(crate) fn operation_inputs(&self, id: TensorId) -> SmallVec<[TensorId; 4]> {
+        let tensors = self.inner.tensors.borrow();
+        SmallVec::from_slice(tensors[id.index()].operation().inputs())
+    }
+
+    pub(crate) fn mark_pending(&self, ids: &[TensorId]) {
+        let mut tensors = self.inner.tensors.borrow_mut();
+        for id in ids {
+            let kind = tensors[id.index()].operation().kind().clone();
+            if matches!(kind, OperationKind::Parameter) {
+                continue;
+            }
+            tensors[id.index()].mark_pending();
+        }
+    }
+
+    pub(crate) fn evaluate(&self, id: TensorId) -> Result<()> {
+        let (operation, inputs) = {
+            let tensors = self.inner.tensors.borrow();
+            let tensor = &tensors[id.index()];
+            if tensor.is_computed() {
+                return Ok(());
+            }
+            (
+                tensor.operation().clone(),
+                tensor.operation().inputs().to_vec(),
+            )
+        };
+        let mut tensors = self.inner.tensors.borrow_mut();
+        let mut arena = self.inner.arena.borrow_mut();
+        operation.kind().eval(&mut tensors, &mut arena, id, &inputs)
+    }
+
+    pub(crate) fn evaluate_order(&self, order: &[TensorId]) -> Result<()> {
+        for id in order {
+            self.evaluate(*id)?;
+        }
+        Ok(())
+    }
+
+    fn assert_same_context(&self, tensor: &Tensor) -> Result<()> {
+        if Rc::ptr_eq(&self.inner, &tensor.ctx.inner) {
+            Ok(())
+        } else {
+            Err(Error::ContextMismatch)
+        }
+    }
+
+    fn register_tensor(
+        &self,
+        shape: Shape,
+        dtype: DType,
+        operation: Operation,
+        storage: std::ops::Range<usize>,
+        computed: bool,
+    ) -> Tensor {
+        let id = self.next_id();
+        let data = TensorData::new(None, shape, dtype, operation, storage, computed);
+        self.inner.tensors.borrow_mut().push(data);
+        Tensor::new(self.clone(), id)
+    }
+
+    fn next_id(&self) -> TensorId {
+        let id = self.inner.next_id.get();
+        self.inner.next_id.set(id + 1);
+        TensorId(id)
+    }
+}
+
+fn shape_from_slice(shape: &[usize]) -> Result<Shape> {
+    if shape.iter().any(|&dim| dim == 0) {
+        return Err(Error::InvalidShape(shape.to_vec()));
+    }
+    Ok(Shape::from_iter(shape.iter().copied()))
+}

--- a/rust/ggml-core/src/dtype.rs
+++ b/rust/ggml-core/src/dtype.rs
@@ -1,0 +1,31 @@
+/// GGML tensor element types supported by the pure Rust implementation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DType {
+    F32,
+    I32,
+    U8,
+}
+
+impl DType {
+    pub fn size_in_bytes(self) -> usize {
+        match self {
+            DType::F32 => std::mem::size_of::<f32>(),
+            DType::I32 => std::mem::size_of::<i32>(),
+            DType::U8 => std::mem::size_of::<u8>(),
+        }
+    }
+
+    pub fn alignment(self) -> usize {
+        self.size_in_bytes().max(1)
+    }
+}
+
+impl std::fmt::Display for DType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DType::F32 => write!(f, "f32"),
+            DType::I32 => write!(f, "i32"),
+            DType::U8 => write!(f, "u8"),
+        }
+    }
+}

--- a/rust/ggml-core/src/error.rs
+++ b/rust/ggml-core/src/error.rs
@@ -1,0 +1,40 @@
+use std::fmt;
+
+use thiserror::Error;
+
+use crate::tensor::TensorId;
+
+#[derive(Debug, Error)]
+pub enum Error {
+    #[error(
+        "out of memory: requested {requested} bytes but only {available} bytes remain in arena"
+    )]
+    OutOfMemory { requested: usize, available: usize },
+    #[error("invalid alignment: {0}")]
+    InvalidAlignment(usize),
+    #[error("invalid shape: {0:?}")]
+    InvalidShape(Vec<usize>),
+    #[error("shape mismatch: expected {expected:?}, got {actual:?}")]
+    ShapeMismatch {
+        expected: Vec<usize>,
+        actual: Vec<usize>,
+    },
+    #[error("dtype mismatch: {0}")]
+    DTypeMismatch(String),
+    #[error("graph contains a cycle")]
+    GraphCycle,
+    #[error("tensor {0:?} has not been computed")]
+    UninitializedTensor(TensorId),
+    #[error("tensor belongs to a different context")]
+    ContextMismatch,
+    #[error("operation error: {0}")]
+    Operation(String),
+}
+
+pub type Result<T> = std::result::Result<T, Error>;
+
+impl Error {
+    pub(crate) fn dtype_mismatch(expected: impl fmt::Display, actual: impl fmt::Display) -> Self {
+        Self::DTypeMismatch(format!("expected {expected}, got {actual}"))
+    }
+}

--- a/rust/ggml-core/src/graph.rs
+++ b/rust/ggml-core/src/graph.rs
@@ -1,0 +1,97 @@
+use std::collections::HashMap;
+
+use crate::{
+    context::Context,
+    error::{Error, Result},
+    tensor::{Tensor, TensorId},
+};
+
+#[derive(Clone, Debug)]
+pub struct ComputationGraph {
+    ctx: Context,
+    outputs: Vec<TensorId>,
+}
+
+impl ComputationGraph {
+    pub fn new(ctx: Context) -> Self {
+        Self {
+            ctx,
+            outputs: Vec::new(),
+        }
+    }
+
+    pub fn add(&mut self, tensor: &Tensor) {
+        if !self.outputs.iter().any(|id| id == &tensor.id) {
+            self.outputs.push(tensor.id);
+        }
+    }
+
+    pub fn outputs(&self) -> &[TensorId] {
+        &self.outputs
+    }
+
+    pub fn compile(&self) -> Result<GraphExecutor> {
+        let order = topo_sort(&self.ctx, &self.outputs)?;
+        Ok(GraphExecutor {
+            ctx: self.ctx.clone(),
+            order,
+        })
+    }
+
+    pub fn compute(&self) -> Result<()> {
+        let executor = self.compile()?;
+        executor.run()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct GraphExecutor {
+    ctx: Context,
+    order: Vec<TensorId>,
+}
+
+impl GraphExecutor {
+    pub fn run(&self) -> Result<()> {
+        self.ctx.mark_pending(&self.order);
+        self.ctx.evaluate_order(&self.order)
+    }
+
+    pub fn order(&self) -> &[TensorId] {
+        &self.order
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum VisitState {
+    Temporary,
+    Permanent,
+}
+
+fn topo_sort(ctx: &Context, outputs: &[TensorId]) -> Result<Vec<TensorId>> {
+    let mut order = Vec::new();
+    let mut states = HashMap::new();
+    for &id in outputs {
+        dfs(ctx, id, &mut states, &mut order)?;
+    }
+    Ok(order)
+}
+
+fn dfs(
+    ctx: &Context,
+    id: TensorId,
+    states: &mut HashMap<TensorId, VisitState>,
+    order: &mut Vec<TensorId>,
+) -> Result<()> {
+    match states.get(&id) {
+        Some(VisitState::Permanent) => return Ok(()),
+        Some(VisitState::Temporary) => return Err(Error::GraphCycle),
+        None => {}
+    }
+    states.insert(id, VisitState::Temporary);
+    for input in ctx.operation_inputs(id) {
+        dfs(ctx, input, states, order)?;
+    }
+    states.insert(id, VisitState::Permanent);
+    order.push(id);
+    Ok(())
+}

--- a/rust/ggml-core/src/lib.rs
+++ b/rust/ggml-core/src/lib.rs
@@ -1,0 +1,15 @@
+pub mod arena;
+pub mod context;
+pub mod dtype;
+pub mod error;
+pub mod graph;
+pub mod ops;
+pub mod tensor;
+
+pub use arena::MemoryArena;
+pub use context::{Context, ContextBuilder, ContextParams};
+pub use dtype::DType;
+pub use error::{Error, Result};
+pub use graph::{ComputationGraph, GraphExecutor};
+pub use ops::{BinaryOpKind, OperationKind, UnaryOpKind};
+pub use tensor::{Tensor, TensorId};

--- a/rust/ggml-core/src/ops.rs
+++ b/rust/ggml-core/src/ops.rs
@@ -1,0 +1,299 @@
+use smallvec::{smallvec, SmallVec};
+
+use crate::{
+    arena::MemoryArena,
+    dtype::DType,
+    error::{Error, Result},
+    tensor::{TensorData, TensorId},
+};
+
+pub(crate) trait OpKernel {
+    fn eval(
+        &self,
+        tensors: &mut [TensorData],
+        arena: &mut MemoryArena,
+        id: TensorId,
+        inputs: &[TensorId],
+    ) -> Result<()>;
+}
+
+#[derive(Clone, Debug)]
+pub struct Operation {
+    kind: OperationKind,
+    inputs: SmallVec<[TensorId; 4]>,
+}
+
+impl Operation {
+    pub fn constant() -> Self {
+        Self {
+            kind: OperationKind::Constant,
+            inputs: SmallVec::new(),
+        }
+    }
+
+    pub fn parameter() -> Self {
+        Self {
+            kind: OperationKind::Parameter,
+            inputs: SmallVec::new(),
+        }
+    }
+
+    pub fn unary(kind: UnaryOpKind, input: TensorId) -> Self {
+        Self {
+            kind: OperationKind::Unary(kind),
+            inputs: smallvec![input],
+        }
+    }
+
+    pub fn binary(kind: BinaryOpKind, lhs: TensorId, rhs: TensorId) -> Self {
+        Self {
+            kind: OperationKind::Binary(kind),
+            inputs: smallvec![lhs, rhs],
+        }
+    }
+
+    pub fn matmul(lhs: TensorId, rhs: TensorId) -> Self {
+        Self {
+            kind: OperationKind::MatMul,
+            inputs: smallvec![lhs, rhs],
+        }
+    }
+
+    pub fn kind(&self) -> &OperationKind {
+        &self.kind
+    }
+
+    pub fn inputs(&self) -> &[TensorId] {
+        &self.inputs
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum OperationKind {
+    Constant,
+    Parameter,
+    Unary(UnaryOpKind),
+    Binary(BinaryOpKind),
+    MatMul,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum UnaryOpKind {
+    Identity,
+    Neg,
+    Exp,
+    Relu,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum BinaryOpKind {
+    Add,
+    Mul,
+}
+
+impl OpKernel for OperationKind {
+    fn eval(
+        &self,
+        tensors: &mut [TensorData],
+        arena: &mut MemoryArena,
+        id: TensorId,
+        inputs: &[TensorId],
+    ) -> Result<()> {
+        match self {
+            OperationKind::Constant => {
+                tensors[id.index()].mark_computed();
+                Ok(())
+            }
+            OperationKind::Parameter => {
+                if tensors[id.index()].is_computed() {
+                    Ok(())
+                } else {
+                    Err(Error::UninitializedTensor(id))
+                }
+            }
+            OperationKind::Unary(kind) => kind.eval(tensors, arena, id, inputs),
+            OperationKind::Binary(kind) => kind.eval(tensors, arena, id, inputs),
+            OperationKind::MatMul => matmul_eval(tensors, arena, id, inputs),
+        }
+    }
+}
+
+impl UnaryOpKind {
+    fn eval(
+        &self,
+        tensors: &mut [TensorData],
+        arena: &mut MemoryArena,
+        id: TensorId,
+        inputs: &[TensorId],
+    ) -> Result<()> {
+        let input_id = inputs
+            .first()
+            .copied()
+            .ok_or_else(|| Error::Operation("unary op missing input".into()))?;
+        let (input_range, input_dtype) = {
+            let tensors_ref: &[_] = &*tensors;
+            let input = &tensors_ref[input_id.index()];
+            (input.storage(), input.dtype)
+        };
+        let (output_range, output_dtype) = {
+            let tensors_ref: &[_] = &*tensors;
+            let output = &tensors_ref[id.index()];
+            (output.storage(), output.dtype)
+        };
+        if input_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, input_dtype));
+        }
+        if output_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, output_dtype));
+        }
+
+        let input_values = {
+            let view = arena.read_f32(&input_range);
+            view.to_vec()
+        };
+        let mut out = vec![0.0f32; input_values.len()];
+        match self {
+            UnaryOpKind::Identity => out.copy_from_slice(&input_values),
+            UnaryOpKind::Neg => {
+                for (o, v) in out.iter_mut().zip(input_values.iter()) {
+                    *o = -*v;
+                }
+            }
+            UnaryOpKind::Exp => {
+                for (o, v) in out.iter_mut().zip(input_values.iter()) {
+                    *o = v.exp();
+                }
+            }
+            UnaryOpKind::Relu => {
+                for (o, v) in out.iter_mut().zip(input_values.iter()) {
+                    *o = v.max(0.0);
+                }
+            }
+        }
+        arena.write_f32(&output_range, &out);
+        tensors[id.index()].mark_computed();
+        Ok(())
+    }
+}
+
+impl BinaryOpKind {
+    fn eval(
+        &self,
+        tensors: &mut [TensorData],
+        arena: &mut MemoryArena,
+        id: TensorId,
+        inputs: &[TensorId],
+    ) -> Result<()> {
+        if inputs.len() != 2 {
+            return Err(Error::Operation("binary op expects two inputs".into()));
+        }
+        let lhs_id = inputs[0];
+        let rhs_id = inputs[1];
+        let (lhs_range, lhs_dtype, rhs_range, rhs_dtype, output_range) = {
+            let tensors_ref: &[_] = &*tensors;
+            let lhs = &tensors_ref[lhs_id.index()];
+            let rhs = &tensors_ref[rhs_id.index()];
+            let out = &tensors_ref[id.index()];
+            (
+                lhs.storage(),
+                lhs.dtype,
+                rhs.storage(),
+                rhs.dtype,
+                out.storage(),
+            )
+        };
+        let out_dtype = tensors[id.index()].dtype;
+        if lhs_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, lhs_dtype));
+        }
+        if rhs_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, rhs_dtype));
+        }
+        if out_dtype != DType::F32 {
+            return Err(Error::dtype_mismatch(DType::F32, out_dtype));
+        }
+        let lhs_values = {
+            let view = arena.read_f32(&lhs_range);
+            view.to_vec()
+        };
+        let rhs_values = {
+            let view = arena.read_f32(&rhs_range);
+            view.to_vec()
+        };
+        let mut out = vec![0.0f32; lhs_values.len()];
+        match self {
+            BinaryOpKind::Add => {
+                for i in 0..out.len() {
+                    out[i] = lhs_values[i] + rhs_values[i];
+                }
+            }
+            BinaryOpKind::Mul => {
+                for i in 0..out.len() {
+                    out[i] = lhs_values[i] * rhs_values[i];
+                }
+            }
+        }
+        arena.write_f32(&output_range, &out);
+        tensors[id.index()].mark_computed();
+        Ok(())
+    }
+}
+
+fn matmul_eval(
+    tensors: &mut [TensorData],
+    arena: &mut MemoryArena,
+    id: TensorId,
+    inputs: &[TensorId],
+) -> Result<()> {
+    if inputs.len() != 2 {
+        return Err(Error::Operation("matmul expects two inputs".into()));
+    }
+    let lhs_id = inputs[0];
+    let rhs_id = inputs[1];
+    let (lhs_range, lhs_shape, rhs_range, rhs_shape, out_range) = {
+        let tensors_ref: &[_] = &*tensors;
+        let lhs = &tensors_ref[lhs_id.index()];
+        let rhs = &tensors_ref[rhs_id.index()];
+        let out = &tensors_ref[id.index()];
+        (
+            lhs.storage(),
+            lhs.shape.clone(),
+            rhs.storage(),
+            rhs.shape.clone(),
+            out.storage(),
+        )
+    };
+    if lhs_shape.len() != 2 || rhs_shape.len() != 2 {
+        return Err(Error::Operation("matmul only supports 2D tensors".into()));
+    }
+    let m = lhs_shape[0];
+    let k = lhs_shape[1];
+    let k_rhs = rhs_shape[0];
+    let n = rhs_shape[1];
+    if k != k_rhs {
+        return Err(Error::Operation("matmul inner dimensions mismatch".into()));
+    }
+    let lhs_values = {
+        let view = arena.read_f32(&lhs_range);
+        view.to_vec()
+    };
+    let rhs_values = {
+        let view = arena.read_f32(&rhs_range);
+        view.to_vec()
+    };
+    let mut out = vec![0.0f32; m * n];
+    for row in 0..m {
+        for col in 0..n {
+            let mut acc = 0.0f32;
+            for inner in 0..k {
+                let lhs_index = row * k + inner;
+                let rhs_index = inner * n + col;
+                acc += lhs_values[lhs_index] * rhs_values[rhs_index];
+            }
+            out[row * n + col] = acc;
+        }
+    }
+    arena.write_f32(&out_range, &out);
+    tensors[id.index()].mark_computed();
+    Ok(())
+}

--- a/rust/ggml-core/src/tensor.rs
+++ b/rust/ggml-core/src/tensor.rs
@@ -1,0 +1,158 @@
+use std::{fmt, ops::Range};
+
+use smallvec::SmallVec;
+
+use crate::{
+    context::Context,
+    dtype::DType,
+    error::Result,
+    graph::ComputationGraph,
+    ops::{BinaryOpKind, Operation, UnaryOpKind},
+};
+
+pub type Shape = SmallVec<[usize; 4]>;
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
+pub struct TensorId(pub(crate) usize);
+
+impl TensorId {
+    pub(crate) fn index(self) -> usize {
+        self.0
+    }
+}
+
+impl fmt::Display for TensorId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "tensor#{}", self.0)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct TensorData {
+    pub(crate) name: Option<String>,
+    pub(crate) shape: Shape,
+    pub(crate) dtype: DType,
+    pub(crate) operation: Operation,
+    pub(crate) storage: Range<usize>,
+    pub(crate) computed: bool,
+}
+
+impl TensorData {
+    pub(crate) fn new(
+        name: Option<String>,
+        shape: Shape,
+        dtype: DType,
+        operation: Operation,
+        storage: Range<usize>,
+        computed: bool,
+    ) -> Self {
+        Self {
+            name,
+            shape,
+            dtype,
+            operation,
+            storage,
+            computed,
+        }
+    }
+
+    pub(crate) fn elements(&self) -> usize {
+        self.shape.iter().product()
+    }
+
+    pub(crate) fn storage(&self) -> Range<usize> {
+        self.storage.clone()
+    }
+
+    pub(crate) fn mark_computed(&mut self) {
+        self.computed = true;
+    }
+
+    pub(crate) fn mark_pending(&mut self) {
+        self.computed = false;
+    }
+
+    pub(crate) fn is_computed(&self) -> bool {
+        self.computed
+    }
+
+    pub(crate) fn operation(&self) -> &Operation {
+        &self.operation
+    }
+}
+
+#[derive(Clone)]
+pub struct Tensor {
+    pub(crate) ctx: Context,
+    pub(crate) id: TensorId,
+}
+
+impl Tensor {
+    pub(crate) fn new(ctx: Context, id: TensorId) -> Self {
+        Self { ctx, id }
+    }
+
+    pub fn id(&self) -> TensorId {
+        self.id
+    }
+
+    pub fn context(&self) -> &Context {
+        &self.ctx
+    }
+
+    pub fn dtype(&self) -> DType {
+        self.ctx.tensor_dtype(self.id)
+    }
+
+    pub fn shape(&self) -> Shape {
+        self.ctx.tensor_shape(self.id)
+    }
+
+    pub fn elements(&self) -> usize {
+        self.ctx.tensor_elements(self.id)
+    }
+
+    pub fn to_vec(&self) -> Result<Vec<f32>> {
+        self.ctx.tensor_to_vec(self.id)
+    }
+
+    pub fn set_f32(&self, data: &[f32]) -> Result<()> {
+        self.ctx.tensor_set_f32(self.id, data)
+    }
+
+    pub fn set_name<S: Into<String>>(&self, name: S) -> Result<()> {
+        self.ctx.tensor_set_name(self.id, name.into())
+    }
+
+    pub fn add(&self, other: &Tensor) -> Result<Tensor> {
+        self.ctx.binary_op(self, other, BinaryOpKind::Add)
+    }
+
+    pub fn mul(&self, other: &Tensor) -> Result<Tensor> {
+        self.ctx.binary_op(self, other, BinaryOpKind::Mul)
+    }
+
+    pub fn matmul(&self, other: &Tensor) -> Result<Tensor> {
+        self.ctx.matmul(self, other)
+    }
+
+    pub fn apply_unary(&self, kind: UnaryOpKind) -> Result<Tensor> {
+        self.ctx.unary_op(self, kind)
+    }
+
+    pub fn graph(&self) -> ComputationGraph {
+        let mut graph = ComputationGraph::new(self.ctx.clone());
+        graph.add(self);
+        graph
+    }
+}
+
+impl fmt::Debug for Tensor {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tensor")
+            .field("id", &self.id)
+            .field("shape", &self.shape())
+            .field("dtype", &self.dtype())
+            .finish()
+    }
+}

--- a/rust/ggml-core/tests/context.rs
+++ b/rust/ggml-core/tests/context.rs
@@ -1,0 +1,33 @@
+use ggml_core::{Context, ContextBuilder, Error};
+
+#[test]
+fn context_initializes_arena() {
+    let ctx = Context::builder().memory_size(1024).build();
+    let tensor = ctx.tensor_from_f32(&[2, 2], &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    assert_eq!(tensor.shape().as_slice(), &[2, 2]);
+    assert_eq!(tensor.dtype(), ggml_core::DType::F32);
+    assert_eq!(tensor.to_vec().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn parameter_requires_initialization() {
+    let ctx = Context::builder().memory_size(4096).build();
+    let weight = ctx.parameter(&[2, 2]).unwrap();
+    let graph = weight.graph();
+    let err = graph.compute().unwrap_err();
+    assert!(matches!(err, Error::UninitializedTensor(_)));
+
+    weight.set_f32(&[1.0, 2.0, 3.0, 4.0]).unwrap();
+    graph.compute().unwrap();
+    assert_eq!(weight.to_vec().unwrap(), vec![1.0, 2.0, 3.0, 4.0]);
+}
+
+#[test]
+fn arena_out_of_memory() {
+    let ctx = ContextBuilder::default().memory_size(64).build();
+    ctx.tensor_from_f32(&[2, 2], &[0.0, 0.0, 0.0, 0.0]).unwrap();
+    let err = ctx
+        .tensor_from_f32(&[8, 8], &[0.0f32; 64])
+        .expect_err("should exceed arena");
+    assert!(matches!(err, Error::OutOfMemory { .. }));
+}

--- a/rust/ggml-core/tests/graph.rs
+++ b/rust/ggml-core/tests/graph.rs
@@ -1,0 +1,17 @@
+use ggml_core::{ComputationGraph, Context};
+
+#[test]
+fn graph_produces_topological_order() {
+    let ctx = Context::builder().build();
+    let a = ctx.tensor_from_f32(&[2], &[1.0, 2.0]).unwrap();
+    let b = ctx.tensor_from_f32(&[2], &[3.0, 4.0]).unwrap();
+    let sum = a.add(&b).unwrap();
+    let prod = sum.mul(&b).unwrap();
+
+    let mut graph = ComputationGraph::new(ctx.clone());
+    graph.add(&prod);
+    let executor = graph.compile().unwrap();
+
+    let order = executor.order();
+    assert_eq!(order, &[a.id(), b.id(), sum.id(), prod.id()]);
+}

--- a/rust/ggml-core/tests/ops.rs
+++ b/rust/ggml-core/tests/ops.rs
@@ -1,0 +1,64 @@
+use approx::assert_abs_diff_eq;
+use ggml_core::{ComputationGraph, Context, Error};
+
+#[test]
+fn executes_elementwise_add_mul() {
+    let ctx = Context::builder().memory_size(4096).build();
+    let a = ctx.tensor_from_f32(&[4], &[1.0, 2.0, 3.0, 4.0]).unwrap();
+    let b = ctx.tensor_from_f32(&[4], &[5.0, 6.0, 7.0, 8.0]).unwrap();
+    let sum = a.add(&b).unwrap();
+    let prod = sum.mul(&b).unwrap();
+
+    let mut graph = ComputationGraph::new(ctx.clone());
+    graph.add(&prod);
+    graph.compute().unwrap();
+
+    assert_eq!(sum.to_vec().unwrap(), vec![6.0, 8.0, 10.0, 12.0]);
+    assert_eq!(prod.to_vec().unwrap(), vec![30.0, 48.0, 70.0, 96.0]);
+}
+
+#[test]
+fn matmul_matches_reference() {
+    let ctx = Context::builder().memory_size(16 * 1024).build();
+    let lhs = ctx
+        .tensor_from_f32(&[2, 3], &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        .unwrap();
+    let rhs = ctx
+        .tensor_from_f32(&[3, 2], &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0])
+        .unwrap();
+    let product = lhs.matmul(&rhs).unwrap();
+    product.graph().compute().unwrap();
+
+    let result = product.to_vec().unwrap();
+    assert_eq!(result.len(), 4);
+    assert_abs_diff_eq!(result[0], 58.0, epsilon = 1e-6);
+    assert_abs_diff_eq!(result[1], 64.0, epsilon = 1e-6);
+    assert_abs_diff_eq!(result[2], 139.0, epsilon = 1e-6);
+    assert_abs_diff_eq!(result[3], 154.0, epsilon = 1e-6);
+}
+
+#[test]
+fn unary_relu_and_neg() {
+    let ctx = Context::builder().build();
+    let input = ctx.tensor_from_f32(&[3], &[-1.0, 0.5, -3.0]).unwrap();
+    let relu = input.apply_unary(ggml_core::UnaryOpKind::Relu).unwrap();
+    let neg = input.apply_unary(ggml_core::UnaryOpKind::Neg).unwrap();
+
+    let mut graph = ComputationGraph::new(ctx.clone());
+    graph.add(&relu);
+    graph.add(&neg);
+    graph.compute().unwrap();
+
+    assert_eq!(relu.to_vec().unwrap(), vec![0.0, 0.5, 0.0]);
+    assert_eq!(neg.to_vec().unwrap(), vec![1.0, -0.5, 3.0]);
+}
+
+#[test]
+fn context_mismatch_is_reported() {
+    let a_ctx = Context::builder().build();
+    let b_ctx = Context::builder().build();
+    let a = a_ctx.tensor_from_f32(&[2], &[1.0, 2.0]).unwrap();
+    let b = b_ctx.tensor_from_f32(&[2], &[3.0, 4.0]).unwrap();
+    let err = a.add(&b).unwrap_err();
+    assert!(matches!(err, Error::ContextMismatch));
+}


### PR DESCRIPTION
## Summary
- add a new `ggml-core` crate that exposes context management, tensor allocation, and an arena allocator mirroring ggml semantics
- implement operation dispatch with typed enums/traits plus a computation graph scheduler and executor
- recreate ggml coverage with Rust tests for tensor creation, graph execution, unary/binary ops, and matmul

## Testing
- cargo test -p ggml-core

------
https://chatgpt.com/codex/tasks/task_b_68d0ba1601fc832fbddf0798f25e858d