### PR TITLE
Add Rust quantization scaffolding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1642,6 +1642,8 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "bytemuck",
+ "cc",
+ "half",
  "smallvec",
  "thiserror 1.0.69",
 ]

--- a/rust/ggml-core/Cargo.toml
+++ b/rust/ggml-core/Cargo.toml
@@ -5,8 +5,12 @@ edition = "2021"
 
 [dependencies]
 bytemuck = { version = "1.15", features = ["derive"] }
+half = "2.4"
 smallvec = "1.13"
 thiserror = "1.0"
 
 [dev-dependencies]
 approx = "0.5"
+
+[build-dependencies]
+cc = "1.0"

--- a/rust/ggml-core/build.rs
+++ b/rust/ggml-core/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    // Always build the reference quantization helpers so tests can link
+    cc::Build::new()
+        .file("tests/quant_ref.c")
+        .compile("quant_ref");
+}

--- a/rust/ggml-core/src/lib.rs
+++ b/rust/ggml-core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod dtype;
 pub mod error;
 pub mod graph;
 pub mod ops;
+pub mod quant;
 pub mod tensor;
 
 pub use arena::MemoryArena;
@@ -12,4 +13,5 @@ pub use dtype::DType;
 pub use error::{Error, Result};
 pub use graph::{ComputationGraph, GraphExecutor};
 pub use ops::{BinaryOpKind, OperationKind, UnaryOpKind};
+pub use quant::*;
 pub use tensor::{Tensor, TensorId};

--- a/rust/ggml-core/src/quant/mod.rs
+++ b/rust/ggml-core/src/quant/mod.rs
@@ -1,0 +1,15 @@
+use half::f16;
+
+pub mod q4_0;
+
+pub use q4_0::*;
+
+#[inline(always)]
+fn f32_to_f16(val: f32) -> f16 {
+    f16::from_f32(val)
+}
+
+#[inline(always)]
+fn f16_to_f32(val: f16) -> f32 {
+    val.to_f32()
+}

--- a/rust/ggml-core/src/quant/q4_0.rs
+++ b/rust/ggml-core/src/quant/q4_0.rs
@@ -1,0 +1,142 @@
+use crate::quant::{f16_to_f32, f32_to_f16};
+use half::f16;
+
+pub const QK4_0: usize = 32;
+pub const QK8_0: usize = 32;
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BlockQ4_0 {
+    pub d: f16,
+    pub qs: [u8; QK4_0 / 2],
+}
+
+impl Default for BlockQ4_0 {
+    fn default() -> Self {
+        Self {
+            d: f16::from_f32(0.0),
+            qs: [0; QK4_0 / 2],
+        }
+    }
+}
+
+#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct BlockQ8_0 {
+    pub d: f16,
+    pub qs: [i8; QK8_0],
+}
+
+impl Default for BlockQ8_0 {
+    fn default() -> Self {
+        Self {
+            d: f16::from_f32(0.0),
+            qs: [0; QK8_0],
+        }
+    }
+}
+
+pub fn quantize_row_q4_0_ref(x: &[f32], y: &mut [BlockQ4_0]) {
+    assert_eq!(
+        x.len(),
+        y.len() * QK4_0,
+        "input length must equal blocks * QK4_0"
+    );
+
+    for (src, dst) in x.chunks_exact(QK4_0).zip(y.iter_mut()) {
+        let mut amax = 0.0f32;
+        let mut max = 0.0f32;
+
+        for &v in src.iter() {
+            let absv = v.abs();
+            if absv > amax {
+                amax = absv;
+                max = v;
+            }
+        }
+
+        let d = max / -8.0;
+        let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+        dst.d = f32_to_f16(d);
+
+        for (j, dst_q) in dst.qs.iter_mut().enumerate() {
+            let x0 = src[j] * id;
+            let x1 = src[j + QK4_0 / 2] * id;
+
+            let xi0 = ((x0 + 8.5).trunc() as i8).min(15) as u8;
+            let xi1 = ((x1 + 8.5).trunc() as i8).min(15) as u8;
+
+            *dst_q = (xi0 & 0x0F) | ((xi1 & 0x0F) << 4);
+        }
+    }
+}
+
+pub fn dequantize_row_q4_0(x: &[BlockQ4_0], y: &mut [f32]) {
+    assert_eq!(y.len(), x.len() * QK4_0);
+
+    for (block, dst) in x.iter().zip(y.chunks_exact_mut(QK4_0)) {
+        let d = f16_to_f32(block.d);
+        for j in 0..QK4_0 / 2 {
+            let v0 = ((block.qs[j] & 0x0f) as i32) - 8;
+            let v1 = ((block.qs[j] >> 4) as i32) - 8;
+
+            dst[j] = (v0 as f32) * d;
+            dst[j + QK4_0 / 2] = (v1 as f32) * d;
+        }
+    }
+}
+
+pub fn quantize_row_q8_0_ref(x: &[f32], y: &mut [BlockQ8_0]) {
+    assert_eq!(x.len(), y.len() * QK8_0);
+
+    for (src, dst) in x.chunks_exact(QK8_0).zip(y.iter_mut()) {
+        let mut amax = 0.0f32;
+        for &v in src.iter() {
+            amax = amax.max(v.abs());
+        }
+
+        let d = amax / 127.0;
+        let id = if d != 0.0 { 1.0 / d } else { 0.0 };
+        dst.d = f32_to_f16(d);
+
+        for (q, &val) in dst.qs.iter_mut().zip(src.iter()) {
+            let scaled = (val * id).round();
+            let clamped = scaled.clamp(-128.0, 127.0) as i32;
+            *q = clamped as i8;
+        }
+    }
+}
+
+pub fn dequantize_row_q8_0(x: &[BlockQ8_0], y: &mut [f32]) {
+    assert_eq!(y.len(), x.len() * QK8_0);
+
+    for (block, dst) in x.iter().zip(y.chunks_exact_mut(QK8_0)) {
+        let d = f16_to_f32(block.d);
+        for (val, out) in block.qs.iter().zip(dst.iter_mut()) {
+            *out = (*val as f32) * d;
+        }
+    }
+}
+
+pub fn vec_dot_q4_0_q8_0(x: &[BlockQ4_0], y: &[BlockQ8_0]) -> f32 {
+    assert_eq!(x.len(), y.len());
+
+    let mut sumf = 0.0f32;
+    for (xb, yb) in x.iter().zip(y.iter()) {
+        let mut sumi0 = 0i32;
+        let mut sumi1 = 0i32;
+
+        for j in 0..QK4_0 / 2 {
+            let v0 = (xb.qs[j] & 0x0F) as i32 - 8;
+            let v1 = (xb.qs[j] >> 4) as i32 - 8;
+
+            sumi0 += v0 * yb.qs[j] as i32;
+            sumi1 += v1 * yb.qs[j + QK8_0 / 2] as i32;
+        }
+
+        let d = f16_to_f32(xb.d) * f16_to_f32(yb.d);
+        sumf += (sumi0 + sumi1) as f32 * d;
+    }
+
+    sumf
+}

--- a/rust/ggml-core/tests/quant.rs
+++ b/rust/ggml-core/tests/quant.rs
@@ -1,0 +1,124 @@
+use approx::assert_relative_eq;
+use ggml_core::quant::{
+    dequantize_row_q4_0, dequantize_row_q8_0, quantize_row_q4_0_ref, quantize_row_q8_0_ref,
+    vec_dot_q4_0_q8_0, BlockQ4_0, BlockQ8_0, QK4_0, QK8_0,
+};
+
+extern "C" {
+    fn quant_ref_quantize_row_q4_0(x: *const f32, y: *mut BlockQ4_0, k: i64);
+    fn quant_ref_quantize_row_q8_0(x: *const f32, y: *mut BlockQ8_0, k: i64);
+    fn quant_ref_dequantize_row_q4_0(x: *const BlockQ4_0, y: *mut f32, k: i64);
+    fn quant_ref_dequantize_row_q8_0(x: *const BlockQ8_0, y: *mut f32, k: i64);
+    fn quant_ref_vec_dot_q4_0_q8_0(x: *const BlockQ4_0, y: *const BlockQ8_0, n: i64) -> f32;
+}
+
+fn sample_data(len: usize) -> Vec<f32> {
+    (0..len)
+        .map(|i| ((i as f32) * 0.123).sin() * 1.5 + ((i as f32) * 0.321).cos() * 0.75)
+        .collect()
+}
+
+fn blocks_from_c<T: Default + Clone>(len: usize) -> Vec<T> {
+    vec![T::default(); len]
+}
+
+#[test]
+fn quantize_q4_0_matches_c() {
+    const N: usize = 4 * QK4_0;
+    let input = sample_data(N);
+
+    let mut rust_blocks = blocks_from_c::<BlockQ4_0>(N / QK4_0);
+    quantize_row_q4_0_ref(&input, &mut rust_blocks);
+
+    let mut c_blocks = blocks_from_c::<BlockQ4_0>(N / QK4_0);
+    unsafe {
+        quant_ref_quantize_row_q4_0(input.as_ptr(), c_blocks.as_mut_ptr(), N as i64);
+    }
+
+    for (r, c) in rust_blocks.iter().zip(c_blocks.iter()) {
+        assert_eq!(r.d.to_bits(), c.d.to_bits());
+        assert_eq!(r.qs, c.qs);
+    }
+}
+
+#[test]
+fn dequantize_q4_0_matches_c() {
+    const N: usize = 4 * QK4_0;
+    let input = sample_data(N);
+
+    let mut blocks = blocks_from_c::<BlockQ4_0>(N / QK4_0);
+    quantize_row_q4_0_ref(&input, &mut blocks);
+
+    let mut rust_out = vec![0.0f32; N];
+    dequantize_row_q4_0(&blocks, &mut rust_out);
+
+    let mut c_out = vec![0.0f32; N];
+    unsafe {
+        quant_ref_dequantize_row_q4_0(blocks.as_ptr(), c_out.as_mut_ptr(), N as i64);
+    }
+
+    for (r, c) in rust_out.iter().zip(c_out.iter()) {
+        assert_relative_eq!(r, c, epsilon = 1e-5f32);
+    }
+}
+
+#[test]
+fn quantize_q8_0_matches_c() {
+    const N: usize = 4 * QK8_0;
+    let input = sample_data(N);
+
+    let mut rust_blocks = blocks_from_c::<BlockQ8_0>(N / QK8_0);
+    quantize_row_q8_0_ref(&input, &mut rust_blocks);
+
+    let mut c_blocks = blocks_from_c::<BlockQ8_0>(N / QK8_0);
+    unsafe {
+        quant_ref_quantize_row_q8_0(input.as_ptr(), c_blocks.as_mut_ptr(), N as i64);
+    }
+
+    for (r, c) in rust_blocks.iter().zip(c_blocks.iter()) {
+        assert_eq!(r.d.to_bits(), c.d.to_bits());
+        assert_eq!(r.qs, c.qs);
+    }
+}
+
+#[test]
+fn dequantize_q8_0_matches_c() {
+    const N: usize = 4 * QK8_0;
+    let input = sample_data(N);
+
+    let mut blocks = blocks_from_c::<BlockQ8_0>(N / QK8_0);
+    quantize_row_q8_0_ref(&input, &mut blocks);
+
+    let mut rust_out = vec![0.0f32; N];
+    dequantize_row_q8_0(&blocks, &mut rust_out);
+
+    let mut c_out = vec![0.0f32; N];
+    unsafe {
+        quant_ref_dequantize_row_q8_0(blocks.as_ptr(), c_out.as_mut_ptr(), N as i64);
+    }
+
+    for (r, c) in rust_out.iter().zip(c_out.iter()) {
+        assert_relative_eq!(r, c, epsilon = 1e-5f32);
+    }
+}
+
+#[test]
+fn vec_dot_q4_0_q8_0_matches_c() {
+    const N: usize = 4 * QK4_0;
+    let x_data = sample_data(N);
+    let y_data = sample_data(N)
+        .into_iter()
+        .map(|v| v * 0.5)
+        .collect::<Vec<_>>();
+
+    let mut x_blocks = blocks_from_c::<BlockQ4_0>(N / QK4_0);
+    let mut y_blocks = blocks_from_c::<BlockQ8_0>(N / QK8_0);
+    quantize_row_q4_0_ref(&x_data, &mut x_blocks);
+    quantize_row_q8_0_ref(&y_data, &mut y_blocks);
+
+    let rust = vec_dot_q4_0_q8_0(&x_blocks, &y_blocks);
+    let c_val =
+        unsafe { quant_ref_vec_dot_q4_0_q8_0(x_blocks.as_ptr(), y_blocks.as_ptr(), N as i64) };
+
+    assert_relative_eq!(rust, c_val, epsilon = 1e-3f32);
+}

--- a/rust/ggml-core/tests/quant_ref.c
+++ b/rust/ggml-core/tests/quant_ref.c
@@ -1,0 +1,203 @@
+#include <stdint.h>
+#include <math.h>
+#include <string.h>
+
+typedef uint16_t ggml_fp16_t;
+
+static inline uint32_t fp32_to_bits(float f) {
+    union {
+        float f;
+        uint32_t u;
+    } tmp = { .f = f };
+    return tmp.u;
+}
+
+static inline float fp32_from_bits(uint32_t w) {
+    union {
+        uint32_t u;
+        float f;
+    } tmp = { .u = w };
+    return tmp.f;
+}
+
+static inline float ggml_compute_fp16_to_fp32(ggml_fp16_t h) {
+    const uint32_t w = (uint32_t)h << 16;
+    const uint32_t sign = w & UINT32_C(0x80000000);
+    const uint32_t two_w = w + w;
+
+    const uint32_t exp_offset = UINT32_C(0xE0) << 23;
+#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || defined(__GNUC__) && !defined(__STRICT_ANSI__)) && (!defined(__cplusplus) || __cplusplus >= 201703L)
+    const float exp_scale = 0x1.0p-112f;
+#else
+    const float exp_scale = fp32_from_bits(UINT32_C(0x7800000));
+#endif
+    const float normalized_value = fp32_from_bits((two_w >> 4) + exp_offset) * exp_scale;
+
+    const uint32_t magic_mask = UINT32_C(126) << 23;
+    const float magic_bias = 0.5f;
+    const float denormalized_value = fp32_from_bits((two_w >> 17) | magic_mask) - magic_bias;
+
+    const uint32_t denormalized_cutoff = UINT32_C(1) << 27;
+    const uint32_t result = sign |
+        (two_w < denormalized_cutoff ? fp32_to_bits(denormalized_value) : fp32_to_bits(normalized_value));
+    return fp32_from_bits(result);
+}
+
+static inline ggml_fp16_t ggml_compute_fp32_to_fp16(float f) {
+#if (defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L) || defined(__GNUC__) && !defined(__STRICT_ANSI__)) && (!defined(__cplusplus) || __cplusplus >= 201703L)
+    const float scale_to_inf = 0x1.0p+112f;
+    const float scale_to_zero = 0x1.0p-110f;
+#else
+    const float scale_to_inf = fp32_from_bits(UINT32_C(0x77800000));
+    const float scale_to_zero = fp32_from_bits(UINT32_C(0x08800000));
+#endif
+    float base = (fabsf(f) * scale_to_inf) * scale_to_zero;
+
+    const uint32_t w = fp32_to_bits(f);
+    const uint32_t shl1_w = w + w;
+    const uint32_t sign = w & UINT32_C(0x80000000);
+    uint32_t bias = shl1_w & UINT32_C(0xFF000000);
+    if (bias < UINT32_C(0x71000000)) {
+        bias = UINT32_C(0x71000000);
+    }
+
+    base = fp32_from_bits((bias >> 1) + UINT32_C(0x07800000)) + base;
+    const uint32_t bits = fp32_to_bits(base);
+    const uint32_t exp_bits = (bits >> 13) & UINT32_C(0x00007C00);
+    const uint32_t mantissa_bits = bits & UINT32_C(0x00000FFF);
+    const uint32_t nonsign = exp_bits + mantissa_bits;
+    return (sign >> 16) | (shl1_w > UINT32_C(0xFF000000) ? UINT16_C(0x7E00) : nonsign);
+}
+
+#define GGML_FP32_TO_FP16(x) ggml_compute_fp32_to_fp16(x)
+#define GGML_FP16_TO_FP32(x) ggml_compute_fp16_to_fp32(x)
+
+#define QK4_0 32
+#define QK8_0 32
+
+typedef struct {
+    ggml_fp16_t d;
+    uint8_t qs[QK4_0 / 2];
+} block_q4_0;
+
+typedef struct {
+    ggml_fp16_t d;
+    int8_t qs[QK8_0];
+} block_q8_0;
+
+void quant_ref_quantize_row_q4_0(const float * x, block_q4_0 * y, int64_t k) {
+    const int qk = QK4_0;
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        float amax = 0.0f;
+        float max = 0.0f;
+
+        for (int j = 0; j < qk; j++) {
+            const float v = x[i*qk + j];
+            const float av = fabsf(v);
+            if (amax < av) {
+                amax = av;
+                max  = v;
+            }
+        }
+
+        const float d  = max / -8.0f;
+        const float id = d ? 1.0f/d : 0.0f;
+
+        y[i].d = GGML_FP32_TO_FP16(d);
+
+        for (int j = 0; j < qk/2; ++j) {
+            const float x0 = x[i*qk + 0    + j]*id;
+            const float x1 = x[i*qk + qk/2 + j]*id;
+
+            const uint8_t xi0 = (uint8_t)(((int8_t)(x0 + 8.5f)) < 15 ? (int8_t)(x0 + 8.5f) : 15);
+            const uint8_t xi1 = (uint8_t)(((int8_t)(x1 + 8.5f)) < 15 ? (int8_t)(x1 + 8.5f) : 15);
+
+            y[i].qs[j]  = xi0;
+            y[i].qs[j] |= xi1 << 4;
+        }
+    }
+}
+
+void quant_ref_quantize_row_q8_0(const float * x, block_q8_0 * y, int64_t k) {
+    const int qk = QK8_0;
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        float amax = 0.0f;
+
+        for (int j = 0; j < qk; j++) {
+            const float v = fabsf(x[i*qk + j]);
+            if (amax < v) {
+                amax = v;
+            }
+        }
+
+        const float d  = amax / 127.0f;
+        const float id = d ? 1.0f/d : 0.0f;
+
+        y[i].d = GGML_FP32_TO_FP16(d);
+
+        for (int j = 0; j < qk; j++) {
+            const float x0 = x[i*qk + j]*id;
+            const float x1 = roundf(x0);
+            const float x2 = x1 < -128.0f ? -128.0f : (x1 > 127.0f ? 127.0f : x1);
+
+            y[i].qs[j] = (int8_t) x2;
+        }
+    }
+}
+
+void quant_ref_dequantize_row_q4_0(const block_q4_0 * x, float * y, int64_t k) {
+    const int qk = QK4_0;
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        const float d = GGML_FP16_TO_FP32(x[i].d);
+
+        for (int j = 0; j < qk/2; ++j) {
+            const int x0 = (x[i].qs[j] & 0x0F) - 8;
+            const int x1 = (x[i].qs[j] >>   4) - 8;
+
+            y[i*qk + j]       = x0*d;
+            y[i*qk + j + qk/2] = x1*d;
+        }
+    }
+}
+
+void quant_ref_dequantize_row_q8_0(const block_q8_0 * x, float * y, int64_t k) {
+    const int qk = QK8_0;
+    const int nb = k / qk;
+
+    for (int i = 0; i < nb; i++) {
+        const float d = GGML_FP16_TO_FP32(x[i].d);
+
+        for (int j = 0; j < qk; ++j) {
+            y[i*qk + j] = x[i].qs[j]*d;
+        }
+    }
+}
+
+float quant_ref_vec_dot_q4_0_q8_0(const block_q4_0 * x, const block_q8_0 * y, int64_t n) {
+    const int qk = QK8_0;
+    const int nb = n / qk;
+    float sumf = 0.0f;
+
+    for (int ib = 0; ib < nb; ++ib) {
+        int sumi0 = 0;
+        int sumi1 = 0;
+
+        for (int j = 0; j < qk/2; ++j) {
+            const int v0 = (x[ib].qs[j] & 0x0F) - 8;
+            const int v1 = (x[ib].qs[j] >>   4) - 8;
+
+            sumi0 += v0 * y[ib].qs[j];
+            sumi1 += v1 * y[ib].qs[j + qk/2];
+        }
+
+        sumf += (float)(sumi0 + sumi1) * GGML_FP16_TO_FP32(x[ib].d) * GGML_FP16_TO_FP32(y[ib].d);
+    }
+
+    return sumf;
+}


### PR DESCRIPTION
## Summary
- add a new quant module with Rust implementations of the q4_0 and q8_0 blocks along with quantize/dequantize helpers and dot products
- build a small C reference library and parity tests to confirm the Rust implementations reproduce the existing behavior

## Testing
- cargo test (ggml-core)


------
https://chatgpt.com/codex/tasks/task_b_68d691a856b0832fab2b787885ea5c5b